### PR TITLE
feat: add interactive demo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ A full-stack web app to track, organize, and analyze job applications — and th
 - **Frontend**: https://joblog.zacknelson.dev
 - **Backend API**: https://joblog-api.onrender.com
 
+## Demo Mode
+
+- Visiting the site without a `?key=...` query string loads the bundled dataset in `frontend/src/mock/jobs.sample.json`, which uses strict `YYYY-MM-DD` dates and mirrors real status histories for a convincing walk-through.
+- In demo mode the app stays completely client-side: no backend calls, and actions like add/edit/delete are disabled to keep the sample data untouched.
+- Supplying a valid key (e.g. `?key=your-admin-key`) restores the live API connection so authenticated users can create, update, and remove entries.
+- The private deployment continues to track 250+ real applications securely—only anonymized demo data is ever shown publicly.
+
 ## Tech Stack
 
 - **Frontend:** React + Tailwind CSS (Vite)

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ A full-stack web app to track, organize, and analyze job applications — and th
 
 ## Demo Mode
 
-- Visiting the site without a `?key=...` query string loads the bundled dataset in `frontend/src/mock/jobs.sample.json`, which uses strict `YYYY-MM-DD` dates and mirrors real status histories for a convincing walk-through.
-- In demo mode the app stays completely client-side: no backend calls, and actions like add/edit/delete are disabled to keep the sample data untouched.
-- Supplying a valid key (e.g. `?key=your-admin-key`) restores the live API connection so authenticated users can create, update, and remove entries.
-- The private deployment continues to track 250+ real applications securely—only anonymized demo data is ever shown publicly.
+- Visiting the site without a `?key=...` query string runs Job Log fully in the browser with the bundled dataset from `frontend/src/mock/jobs.sample.json` (strict `YYYY-MM-DD` dates, realistic histories).
+- You can add, edit, and delete jobs in demo mode; changes persist for the current tab via `sessionStorage` and never leave the browser.
+- Click **Reset Demo** to restore the original seeded dataset at any time.
+- Supplying a valid key (e.g. `?key=your-admin-key`) reconnects to the live API so authenticated users can manage their private data—now over 250 real applications tracked securely.
 
 ## Tech Stack
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,44 @@ import ApplicationTrends from "./components/ApplicationTrends";
 import DemoBanner from "./components/DemoBanner";
 import mockJobs from "./mock/jobs.sample.json";
 
+const DEMO_STORAGE_KEY = "joblog_demo_state_v1";
+
+const cloneSeedJobs = () => JSON.parse(JSON.stringify(mockJobs));
+
+const loadDemoJobs = () => {
+  if (typeof window === "undefined") {
+    return cloneSeedJobs();
+  }
+
+  try {
+    const raw = window.sessionStorage.getItem(DEMO_STORAGE_KEY);
+    if (!raw) return cloneSeedJobs();
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : cloneSeedJobs();
+  } catch (error) {
+    console.warn("Failed to load demo jobs from sessionStorage:", error);
+    return cloneSeedJobs();
+  }
+};
+
+const saveDemoJobs = (jobs) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(DEMO_STORAGE_KEY, JSON.stringify(jobs));
+  } catch (error) {
+    console.warn("Failed to save demo jobs to sessionStorage:", error);
+  }
+};
+
+const resetDemoJobs = () => {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(DEMO_STORAGE_KEY);
+  } catch (error) {
+    console.warn("Failed to reset demo jobs in sessionStorage:", error);
+  }
+};
+
 function App() {
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -38,7 +76,8 @@ function App() {
       return;
     }
 
-    setJobs(mockJobs);
+    const demoJobs = loadDemoJobs();
+    setJobs(demoJobs);
     setLoading(false);
   }, [hasAdminKey, apiKey]);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -92,6 +92,13 @@ function App() {
     });
   };
 
+  const handleResetDemo = () => {
+    const seedJobs = cloneSeedJobs();
+    resetDemoJobs();
+    saveDemoJobs(seedJobs);
+    setJobs(seedJobs);
+  };
+
   useEffect(() => {
     if (hasAdminKey) {
       setLoading(true);
@@ -146,7 +153,7 @@ function App() {
         </div>
       </div>
 
-      {isDemo && <DemoBanner />}
+      {isDemo && <DemoBanner onReset={handleResetDemo} />}
 
       <JobForm
         onJobAdded={handleJobAdded}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import JobForm from "./components/JobForm";
 import JobList from "./components/JobList";
 import ApplicationTrends from "./components/ApplicationTrends";
+import DemoBanner from "./components/DemoBanner";
 import mockJobs from "./mock/jobs.sample.json";
 
 function App() {
@@ -75,6 +76,8 @@ function App() {
         </div>
       </div>
 
+      {isDemo && <DemoBanner />}
+
       <JobForm
         onJobAdded={handleJobAdded}
         apiKey={apiKey}
@@ -88,13 +91,6 @@ function App() {
         readonly={isDemo}
       />
 
-      {!apiKey && (
-        <div className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
-          <span className="inline-block bg-light-tag-remoteBg text-light-accent dark:bg-dark-card dark:text-dark-tag-text px-3 py-1 rounded border border-light-accent">
-            Demo mode: editing requires admin access
-          </span>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ function App() {
   const params = new URLSearchParams(window.location.search);
   const apiKey = params.get("key");
   const hasAdminKey = Boolean(apiKey);
+  const isDemo = !hasAdminKey;
 
   const handleJobAdded = (newJob) => {
     setJobs((prev) => [...prev, newJob]);
@@ -74,9 +75,18 @@ function App() {
         </div>
       </div>
 
-      <JobForm onJobAdded={handleJobAdded} apiKey={apiKey} />
+      <JobForm
+        onJobAdded={handleJobAdded}
+        apiKey={apiKey}
+        disabled={isDemo}
+      />
       <ApplicationTrends jobs={jobs} />
-      <JobList jobs={jobs} setJobs={setJobs} apiKey={apiKey} />
+      <JobList
+        jobs={jobs}
+        setJobs={setJobs}
+        apiKey={apiKey}
+        readonly={isDemo}
+      />
 
       {!apiKey && (
         <div className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import JobForm from "./components/JobForm";
 import JobList from "./components/JobList";
 import ApplicationTrends from "./components/ApplicationTrends";
+import mockJobs from "./mock/jobs.sample.json";
 
 function App() {
   const [jobs, setJobs] = useState([]);
@@ -12,19 +13,32 @@ function App() {
   }); // New state for dark mode
 
   // Extract API key from URL query string
-  const apiKey = new URLSearchParams(window.location.search).get("key");
+  const params = new URLSearchParams(window.location.search);
+  const apiKey = params.get("key");
+  const hasAdminKey = Boolean(apiKey);
 
   const handleJobAdded = (newJob) => {
     setJobs((prev) => [...prev, newJob]);
   };
 
   useEffect(() => {
-    axios
-      .get(`${import.meta.env.VITE_API_BASE_URL}/jobs/`)
-      .then((response) => setJobs(response.data))
-      .catch((error) => console.error("Error fetching jobs:", error))
-      .finally(() => setLoading(false));
-  }, []);
+    if (hasAdminKey) {
+      setLoading(true);
+      axios
+        .get(
+          `${import.meta.env.VITE_API_BASE_URL}/jobs?key=${encodeURIComponent(
+            apiKey
+          )}`
+        )
+        .then((response) => setJobs(response.data))
+        .catch((error) => console.error("Error fetching jobs:", error))
+        .finally(() => setLoading(false));
+      return;
+    }
+
+    setJobs(mockJobs);
+    setLoading(false);
+  }, [hasAdminKey, apiKey]);
 
   useEffect(() => {
     if (darkMode) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -61,6 +61,37 @@ function App() {
     setJobs((prev) => [...prev, newJob]);
   };
 
+  const handleDemoAdd = (job) => {
+    setJobs((prev) => {
+      const next = [...prev, job];
+      saveDemoJobs(next);
+      return next;
+    });
+  };
+
+  const handleDemoUpdate = (id, patch) => {
+    setJobs((prev) => {
+      const next = prev.map((job) =>
+        job.id === id
+          ? {
+              ...job,
+              ...patch,
+            }
+          : job
+      );
+      saveDemoJobs(next);
+      return next;
+    });
+  };
+
+  const handleDemoDelete = (id) => {
+    setJobs((prev) => {
+      const next = prev.filter((job) => job.id !== id);
+      saveDemoJobs(next);
+      return next;
+    });
+  };
+
   useEffect(() => {
     if (hasAdminKey) {
       setLoading(true);
@@ -120,14 +151,17 @@ function App() {
       <JobForm
         onJobAdded={handleJobAdded}
         apiKey={apiKey}
-        disabled={isDemo}
+        demoMode={isDemo}
+        onDemoAdd={handleDemoAdd}
       />
       <ApplicationTrends jobs={jobs} />
       <JobList
         jobs={jobs}
         setJobs={setJobs}
         apiKey={apiKey}
-        readonly={isDemo}
+        demoMode={isDemo}
+        onDemoUpdate={handleDemoUpdate}
+        onDemoDelete={handleDemoDelete}
       />
 
     </div>

--- a/frontend/src/components/DemoBanner.jsx
+++ b/frontend/src/components/DemoBanner.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const DemoBanner = () => (
+  <div className='mb-6 rounded-lg border border-light-accent/40 bg-light-background p-4 text-sm text-light-text shadow-sm dark:border-dark-accent/60 dark:bg-dark-card dark:text-dark-text'>
+    <p className='font-medium text-light-accent dark:text-dark-accent'>
+      Demo data only — personal data hidden for privacy.
+    </p>
+    <p className='mt-1 text-xs text-gray-600 dark:text-gray-300'>
+      This public demo uses sample data for privacy. In personal use, JobLog has
+      tracked 250+ real applications.
+    </p>
+  </div>
+);
+
+export default DemoBanner;

--- a/frontend/src/components/DemoBanner.jsx
+++ b/frontend/src/components/DemoBanner.jsx
@@ -1,14 +1,24 @@
 import React from 'react';
 
-const DemoBanner = () => (
+const DemoBanner = ({ onReset = () => {} }) => (
   <div className='mb-6 rounded-lg border border-light-accent/40 bg-light-background p-4 text-sm text-light-text shadow-sm dark:border-dark-accent/60 dark:bg-dark-card dark:text-dark-text'>
-    <p className='font-medium text-light-accent dark:text-dark-accent'>
-      Demo data only — personal data hidden for privacy.
-    </p>
-    <p className='mt-1 text-xs text-gray-600 dark:text-gray-300'>
-      This public demo uses sample data for privacy. In personal use, JobLog has
-      tracked 250+ real applications.
-    </p>
+    <div className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
+      <div>
+        <p className='font-medium text-light-accent dark:text-dark-accent'>
+          Demo data only — personal data hidden for privacy.
+        </p>
+        <p className='mt-1 text-xs text-gray-600 dark:text-gray-300'>
+          Changes persist locally for this tab using sessionStorage. Reset anytime to restore the bundled sample data.
+        </p>
+      </div>
+      <button
+        type='button'
+        onClick={onReset}
+        className='self-start rounded border border-light-accent px-3 py-1 text-xs font-semibold text-light-accent transition hover:bg-light-accent hover:text-white dark:border-dark-accent dark:text-dark-accent dark:hover:bg-dark-accent dark:hover:text-dark-card'
+      >
+        Reset Demo
+      </button>
+    </div>
   </div>
 );
 

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -9,6 +9,7 @@
  * Props
  *  - onJobAdded(job): function called with the created job response.
  *  - apiKey: optional string; appended as ?key=... to support admin/demo mode.
+ *  - disabled: when true, renders a read-only demo version of the form.
  *
  * Note: some helpers here are duplicated in JobList. Consider extracting to
  * /frontend/src/utils/date.ts(x) in a follow-up so the app uses one source.
@@ -42,7 +43,7 @@ const todayYMD = () => {
   return `${y}-${m}-${day}`;
 };
 
-const JobForm = ({ onJobAdded, apiKey }) => {
+const JobForm = ({ onJobAdded, apiKey, disabled = false }) => {
   const [formData, setFormData] = useState({
     title: '',
     company: '',
@@ -72,11 +73,13 @@ const JobForm = ({ onJobAdded, apiKey }) => {
   const textAreaBase = inputBase;
 
   const handleChange = (e) => {
+    if (disabled) return;
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    if (disabled) return;
     const query = apiKey ? `?key=${apiKey}` : '';
     const dateNorm = normalizeYMD(formData.date_applied || todayYMD());
     const tagsNorm = selectedTags
@@ -127,6 +130,7 @@ const JobForm = ({ onJobAdded, apiKey }) => {
           placeholder='Job Title'
           required
           className={inputBase}
+          disabled={disabled}
         />
         <input
           name='company'
@@ -135,6 +139,7 @@ const JobForm = ({ onJobAdded, apiKey }) => {
           placeholder='Company'
           required
           className={inputBase}
+          disabled={disabled}
         />
         <input
           name='link'
@@ -142,6 +147,7 @@ const JobForm = ({ onJobAdded, apiKey }) => {
           onChange={handleChange}
           placeholder='Job Link'
           className={inputBase}
+          disabled={disabled}
         />
         <input
           type='date'
@@ -157,12 +163,14 @@ const JobForm = ({ onJobAdded, apiKey }) => {
             'dark:[&::-webkit-calendar-picker-indicator]:invert',
             '[&::-webkit-calendar-picker-indicator]:cursor-pointer'
           ].join(' ')}
+          disabled={disabled}
         />
         <select
           name='status'
           value={formData.status}
           onChange={handleChange}
           className={selectBase}
+          disabled={disabled}
         >
           <option value='Applied'>Applied</option>
           <option value='Interviewing'>Interviewing</option>
@@ -176,6 +184,7 @@ const JobForm = ({ onJobAdded, apiKey }) => {
           placeholder='Notes'
           rows={3}
           className={textAreaBase}
+          disabled={disabled}
         />
         <div>
           <label className='font-semibold'>Tags:</label>
@@ -187,7 +196,9 @@ const JobForm = ({ onJobAdded, apiKey }) => {
                   className='h-4 w-4 accent-light-accent dark:accent-dark-accent bg-light-background dark:bg-dark-card border border-gray-300 dark:border-gray-600 focus:ring-light-accent dark:focus:ring-dark-accent focus:ring-offset-1'
                   value={tag}
                   checked={selectedTags.includes(tag)}
+                  disabled={disabled}
                   onChange={(e) => {
+                    if (disabled) return;
                     if (e.target.checked) {
                       setSelectedTags([...selectedTags, tag]);
                     } else {
@@ -202,10 +213,16 @@ const JobForm = ({ onJobAdded, apiKey }) => {
         </div>
         <button
           type='submit'
-          className='bg-light-accent text-white dark:bg-dark-accent px-4 py-2 rounded transition hover:bg-light-accentHover dark:hover:bg-dark-accentHover dark:hover:shadow-[0_0_10px_var(--tw-shadow-color)] shadow-dark-accentHover'
+          className='bg-light-accent text-white dark:bg-dark-accent px-4 py-2 rounded transition hover:bg-light-accentHover dark:hover:bg-dark-accentHover dark:hover:shadow-[0_0_10px_var(--tw-shadow-color)] shadow-dark-accentHover disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-light-accent'
+          disabled={disabled}
         >
-          Add Job
+          {disabled ? 'Add Job (demo disabled)' : 'Add Job'}
         </button>
+        {disabled && (
+          <p className='text-xs text-gray-500 mt-1 dark:text-gray-400'>
+            Demo mode: adding jobs is disabled.
+          </p>
+        )}
       </div>
     </form>
   );

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -9,7 +9,8 @@
  * Props
  *  - onJobAdded(job): function called with the created job response.
  *  - apiKey: optional string; appended as ?key=... to support admin/demo mode.
- *  - disabled: when true, renders a read-only demo version of the form.
+ *  - demoMode: when true, emits jobs locally without calling the API.
+ *  - onDemoAdd(job): optional callback used to add jobs in demo mode.
  *
  * Note: some helpers here are duplicated in JobList. Consider extracting to
  * /frontend/src/utils/date.ts(x) in a follow-up so the app uses one source.
@@ -43,7 +44,7 @@ const todayYMD = () => {
   return `${y}-${m}-${day}`;
 };
 
-const JobForm = ({ onJobAdded, apiKey, disabled = false }) => {
+const JobForm = ({ onJobAdded, apiKey, demoMode = false, onDemoAdd }) => {
   const [formData, setFormData] = useState({
     title: '',
     company: '',
@@ -73,33 +74,53 @@ const JobForm = ({ onJobAdded, apiKey, disabled = false }) => {
   const textAreaBase = inputBase;
 
   const handleChange = (e) => {
-    if (disabled) return;
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (disabled) return;
-    const query = apiKey ? `?key=${apiKey}` : '';
-    const dateNorm = normalizeYMD(formData.date_applied || todayYMD());
+    const resolvedDate = normalizeYMD(formData.date_applied || todayYMD());
     const tagsNorm = selectedTags
       .map((t) => t.trim())
       .filter(Boolean)
       .join(',');
 
+    const payload = {
+      ...formData,
+      tags: tagsNorm,
+      date_applied: resolvedDate,
+      status_history: [
+        {
+          status: formData.status,
+          date: resolvedDate
+        }
+      ]
+    };
+
+    if (demoMode && typeof onDemoAdd === 'function') {
+      const demoJob = {
+        ...payload,
+        id: Date.now() + Math.floor(Math.random() * 1000)
+      };
+      onDemoAdd(demoJob);
+      setFormData({
+        title: '',
+        company: '',
+        link: '',
+        status: 'Applied',
+        date_applied: '',
+        notes: '',
+        status_history: []
+      });
+      setSelectedTags([]);
+      return;
+    }
+
+    const query = apiKey ? `?key=${apiKey}` : '';
+
     // Build normalized payload: strict date + comma-joined tags + initial status entry
     axios
-      .post(`${import.meta.env.VITE_API_BASE_URL}/jobs/${query}`, {
-        ...formData,
-        tags: tagsNorm,
-        date_applied: dateNorm,
-        status_history: [
-          {
-            status: formData.status,
-            date: dateNorm
-          }
-        ]
-      })
+      .post(`${import.meta.env.VITE_API_BASE_URL}/jobs/${query}`, payload)
       .then((res) => {
         onJobAdded(res.data);
         setFormData({
@@ -130,7 +151,6 @@ const JobForm = ({ onJobAdded, apiKey, disabled = false }) => {
           placeholder='Job Title'
           required
           className={inputBase}
-          disabled={disabled}
         />
         <input
           name='company'
@@ -139,7 +159,6 @@ const JobForm = ({ onJobAdded, apiKey, disabled = false }) => {
           placeholder='Company'
           required
           className={inputBase}
-          disabled={disabled}
         />
         <input
           name='link'
@@ -147,7 +166,6 @@ const JobForm = ({ onJobAdded, apiKey, disabled = false }) => {
           onChange={handleChange}
           placeholder='Job Link'
           className={inputBase}
-          disabled={disabled}
         />
         <input
           type='date'
@@ -163,14 +181,12 @@ const JobForm = ({ onJobAdded, apiKey, disabled = false }) => {
             'dark:[&::-webkit-calendar-picker-indicator]:invert',
             '[&::-webkit-calendar-picker-indicator]:cursor-pointer'
           ].join(' ')}
-          disabled={disabled}
         />
         <select
           name='status'
           value={formData.status}
           onChange={handleChange}
           className={selectBase}
-          disabled={disabled}
         >
           <option value='Applied'>Applied</option>
           <option value='Interviewing'>Interviewing</option>
@@ -184,7 +200,6 @@ const JobForm = ({ onJobAdded, apiKey, disabled = false }) => {
           placeholder='Notes'
           rows={3}
           className={textAreaBase}
-          disabled={disabled}
         />
         <div>
           <label className='font-semibold'>Tags:</label>
@@ -196,9 +211,7 @@ const JobForm = ({ onJobAdded, apiKey, disabled = false }) => {
                   className='h-4 w-4 accent-light-accent dark:accent-dark-accent bg-light-background dark:bg-dark-card border border-gray-300 dark:border-gray-600 focus:ring-light-accent dark:focus:ring-dark-accent focus:ring-offset-1'
                   value={tag}
                   checked={selectedTags.includes(tag)}
-                  disabled={disabled}
                   onChange={(e) => {
-                    if (disabled) return;
                     if (e.target.checked) {
                       setSelectedTags([...selectedTags, tag]);
                     } else {
@@ -213,16 +226,10 @@ const JobForm = ({ onJobAdded, apiKey, disabled = false }) => {
         </div>
         <button
           type='submit'
-          className='bg-light-accent text-white dark:bg-dark-accent px-4 py-2 rounded transition hover:bg-light-accentHover dark:hover:bg-dark-accentHover dark:hover:shadow-[0_0_10px_var(--tw-shadow-color)] shadow-dark-accentHover disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-light-accent'
-          disabled={disabled}
+          className='bg-light-accent text-white dark:bg-dark-accent px-4 py-2 rounded transition hover:bg-light-accentHover dark:hover:bg-dark-accentHover dark:hover:shadow-[0_0_10px_var(--tw-shadow-color)] shadow-dark-accentHover'
         >
-          {disabled ? 'Add Job (demo disabled)' : 'Add Job'}
+          Add Job
         </button>
-        {disabled && (
-          <p className='text-xs text-gray-500 mt-1 dark:text-gray-400'>
-            Demo mode: adding jobs is disabled.
-          </p>
-        )}
       </div>
     </form>
   );

--- a/frontend/src/mock/jobs.sample.json
+++ b/frontend/src/mock/jobs.sample.json
@@ -1,0 +1,241 @@
+[
+  {
+    "id": 982311,
+    "title": "Senior Frontend Engineer",
+    "company": "Nimbus Analytics",
+    "link": "https://nimbusanalytics.com/careers/frontend",
+    "notes": "Reached out through alumni network.",
+    "tags": "Remote,Referral",
+    "date_applied": "2024-01-05",
+    "status": "Interviewing",
+    "status_history": [
+      { "status": "Applied", "date": "2024-01-05" },
+      { "status": "Interviewing", "date": "2024-01-17" },
+      { "status": "Interviewing", "date": "2024-01-24" }
+    ]
+  },
+  {
+    "id": 982654,
+    "title": "Data Scientist",
+    "company": "QuantLeaf",
+    "link": "https://quantleaf.ai/jobs/data-scientist",
+    "notes": "Technical screen scheduled for early February.",
+    "tags": "Hybrid,Startup",
+    "date_applied": "2024-01-12",
+    "status": "Interviewing",
+    "status_history": [
+      { "status": "Applied", "date": "2024-01-12" },
+      { "status": "Interviewing", "date": "2024-01-26" }
+    ]
+  },
+  {
+    "id": 983120,
+    "title": "Platform Engineer",
+    "company": "Helios Cloud",
+    "link": "https://jobs.helioscloud.io/platform-engineer",
+    "notes": "Urgent replacement for on-call rotation.",
+    "tags": "Remote,Urgent",
+    "date_applied": "2024-01-19",
+    "status": "Applied",
+    "status_history": [
+      { "status": "Applied", "date": "2024-01-19" }
+    ]
+  },
+  {
+    "id": 983874,
+    "title": "Product Manager",
+    "company": "Evergreen CRM",
+    "link": "https://evergreencrm.com/careers/pm",
+    "notes": "Referred by mentor; case study due next week.",
+    "tags": "Hybrid,Referral",
+    "date_applied": "2024-01-22",
+    "status": "Interviewing",
+    "status_history": [
+      { "status": "Applied", "date": "2024-01-22" },
+      { "status": "Interviewing", "date": "2024-01-30" },
+      { "status": "Interviewing", "date": "2024-02-08" }
+    ]
+  },
+  {
+    "id": 984205,
+    "title": "Backend Engineer",
+    "company": "Blue Harbor Logistics",
+    "link": "https://blueharbor.io/jobs/backend",
+    "notes": "Follow up sent to recruiter after assessment.",
+    "tags": "Remote",
+    "date_applied": "2024-01-26",
+    "status": "Applied",
+    "status_history": [
+      { "status": "Applied", "date": "2024-01-26" }
+    ]
+  },
+  {
+    "id": 984612,
+    "title": "Staff iOS Engineer",
+    "company": "Aurora Health",
+    "link": "https://aurorahealth.app/careers/ios-staff-engineer",
+    "notes": "Mobile team growing; onsite interview in March.",
+    "tags": "Hybrid,On-Site",
+    "date_applied": "2024-02-02",
+    "status": "Interviewing",
+    "status_history": [
+      { "status": "Applied", "date": "2024-02-02" },
+      { "status": "Interviewing", "date": "2024-02-16" }
+    ]
+  },
+  {
+    "id": 985043,
+    "title": "Machine Learning Engineer",
+    "company": "SignalForge",
+    "link": "https://signalforge.com/careers/ml-engineer",
+    "notes": "Take-home challenge submitted.",
+    "tags": "Remote,Startup",
+    "date_applied": "2024-02-09",
+    "status": "Applied",
+    "status_history": [
+      { "status": "Applied", "date": "2024-02-09" }
+    ]
+  },
+  {
+    "id": 985477,
+    "title": "DevOps Engineer",
+    "company": "Coastal Retail",
+    "link": "https://careers.coastalretail.com/devops",
+    "notes": "Infrastructure modernization initiative.",
+    "tags": "On-Site,Urgent",
+    "date_applied": "2024-02-13",
+    "status": "Offer",
+    "status_history": [
+      { "status": "Applied", "date": "2024-02-13" },
+      { "status": "Interviewing", "date": "2024-02-21" },
+      { "status": "Offer", "date": "2024-03-05" }
+    ]
+  },
+  {
+    "id": 986019,
+    "title": "Full Stack Engineer",
+    "company": "Harborlight Labs",
+    "link": "https://harborlightlabs.com/jobs/full-stack",
+    "notes": "Met founders at local meetup; strong culture fit.",
+    "tags": "Startup,On-Site",
+    "date_applied": "2024-02-20",
+    "status": "Interviewing",
+    "status_history": [
+      { "status": "Applied", "date": "2024-02-20" },
+      { "status": "Interviewing", "date": "2024-03-01" },
+      { "status": "Interviewing", "date": "2024-03-12" }
+    ]
+  },
+  {
+    "id": 986542,
+    "title": "Security Engineer",
+    "company": "Sentinel One Labs",
+    "link": "https://sentinelonelabs.com/jobs/security",
+    "notes": "Panel interview scheduled; requires relocation.",
+    "tags": "On-Site",
+    "date_applied": "2024-02-27",
+    "status": "Applied",
+    "status_history": [
+      { "status": "Applied", "date": "2024-02-27" }
+    ]
+  },
+  {
+    "id": 987088,
+    "title": "Data Platform Lead",
+    "company": "Latitude Ventures",
+    "link": "https://jobs.latitude.vc/data-platform-lead",
+    "notes": "VC portfolio company seeking hands-on lead.",
+    "tags": "Remote,Referral",
+    "date_applied": "2024-03-04",
+    "status": "Offer",
+    "status_history": [
+      { "status": "Applied", "date": "2024-03-04" },
+      { "status": "Interviewing", "date": "2024-03-18" },
+      { "status": "Offer", "date": "2024-04-02" }
+    ]
+  },
+  {
+    "id": 987654,
+    "title": "Site Reliability Engineer",
+    "company": "Atlas Maps",
+    "link": "https://atlasmaps.com/careers/sre",
+    "notes": "Discussed on-call rotations; hybrid schedule.",
+    "tags": "Hybrid,Urgent",
+    "date_applied": "2024-03-08",
+    "status": "Interviewing",
+    "status_history": [
+      { "status": "Applied", "date": "2024-03-08" },
+      { "status": "Interviewing", "date": "2024-03-20" },
+      { "status": "Interviewing", "date": "2024-04-03" }
+    ]
+  },
+  {
+    "id": 988112,
+    "title": "Research Engineer",
+    "company": "DeepNorth AI",
+    "link": "https://deepnorth.ai/careers/research-engineer",
+    "notes": "PhD-heavy team; waiting on feedback from panel.",
+    "tags": "Remote",
+    "date_applied": "2024-03-15",
+    "status": "Applied",
+    "status_history": [
+      { "status": "Applied", "date": "2024-03-15" }
+    ]
+  },
+  {
+    "id": 988540,
+    "title": "Senior Product Designer",
+    "company": "Waveform Finance",
+    "link": "https://waveform.finance/careers/product-designer",
+    "notes": "Design exercise complete; feedback pending.",
+    "tags": "Remote,Referral",
+    "date_applied": "2024-03-19",
+    "status": "Rejected",
+    "status_history": [
+      { "status": "Applied", "date": "2024-03-19" },
+      { "status": "Interviewing", "date": "2024-04-01" },
+      { "status": "Rejected", "date": "2024-04-08" }
+    ]
+  },
+  {
+    "id": 989005,
+    "title": "Analytics Engineer",
+    "company": "Brightleaf Foods",
+    "link": "https://brightleaffoods.com/careers/analytics-engineer",
+    "notes": "On-site plant tour included in final round.",
+    "tags": "On-Site",
+    "date_applied": "2024-03-25",
+    "status": "Interviewing",
+    "status_history": [
+      { "status": "Applied", "date": "2024-03-25" },
+      { "status": "Interviewing", "date": "2024-04-05" }
+    ]
+  },
+  {
+    "id": 989442,
+    "title": "Growth Marketing Manager",
+    "company": "Orbit Commerce",
+    "link": "https://orbitcommerce.com/jobs/growth-marketing-manager",
+    "notes": "Case presentation scheduled for next sprint.",
+    "tags": "Hybrid,Startup",
+    "date_applied": "2024-03-29",
+    "status": "Applied",
+    "status_history": [
+      { "status": "Applied", "date": "2024-03-29" }
+    ]
+  },
+  {
+    "id": 989980,
+    "title": "Solutions Architect",
+    "company": "Cobalt Systems",
+    "link": "https://cobaltsystems.com/careers/solutions-architect",
+    "notes": "Government contract; security clearance required.",
+    "tags": "On-Site",
+    "date_applied": "2024-04-02",
+    "status": "Rejected",
+    "status_history": [
+      { "status": "Applied", "date": "2024-04-02" },
+      { "status": "Rejected", "date": "2024-04-15" }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- load mock data into sessionStorage so demo mode stays client-side and interactive
- add local add/update/delete handlers plus Reset Demo banner CTA
- keep mock dates aligned near today for believable analytics and update README docs

## Testing
- npm run dev (no ?key): add → edit → delete → reset demo
- refresh same tab: confirm sessionStorage retains edits until reset
- open ?key=YOUR_KEY with backend running: verify live API add/edit/delete still work
- toggled filters/CSV export/ApplicationTrends in both modes
