### PR TITLE
feat: add local-first personal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A full-stack web app to track, organize, and analyze job applications — and th
 - 7-day application trend chart (Bar graph)
 - Status history tracking (every status change is logged)
 - Enhanced analytics (based on full status history, not just current state)
-- Admin-only editing via secure API key (public visitors view in read-only demo mode)
-- “Demo Mode” banner shown to public visitors
+- Multi-mode support: Admin (API), Personal (IndexedDB), and Demo (sessionStorage) with onboarding chooser
+- Mode badge and contextual messaging so visitors always know which mode they are using
 - Loading spinner during backend startup (Render cold start)
 - React frontend communicates with FastAPI backend using Axios
 - Backend stores jobs in a PostgreSQL database using SQLAlchemy ORM
@@ -49,12 +49,19 @@ A full-stack web app to track, organize, and analyze job applications — and th
 - **Frontend**: https://joblog.zacknelson.dev
 - **Backend API**: https://joblog-api.onrender.com
 
-## Demo Mode
+## Modes
 
-- Visiting the site without a `?key=...` query string runs Job Log fully in the browser with the bundled dataset from `frontend/src/mock/jobs.sample.json` (strict `YYYY-MM-DD` dates, realistic histories).
-- You can add, edit, and delete jobs in demo mode; changes persist for the current tab via `sessionStorage` and never leave the browser.
-- Click **Reset Demo** to restore the original seeded dataset at any time.
-- Supplying a valid key (e.g. `?key=your-admin-key`) reconnects to the live API so authenticated users can manage their private data—now over 250 real applications tracked securely.
+- **Personal (Local)** — When no `?key=` is present and you choose *Personal* on first launch, JobLog stores everything privately in IndexedDB. Changes persist across browser sessions, you can export/import JSON backups, and nothing is synced or uploaded.
+- **Public Demo** — Also available without a key. Choose *Demo* to load a curated dataset (dates dynamically align with “last 7 days” for believable analytics). Data lives in `sessionStorage`, so it disappears when the tab closes or when you hit Reset Demo.
+- **Admin (Private)** — Visiting with a valid `?key=...` keeps the original server-backed behavior: FastAPI, PostgreSQL, and all real data. This is how the private production instance continues to track 250+ applications.
+
+An onboarding modal guides first-time visitors without keys. You can revisit the choice from the Settings drawer.
+
+### Privacy & Backups
+
+- Local/Demo modes never fire axios/fetch calls; they only interact with browser storage.
+- Personal mode offers a backup reminder if you haven’t exported in 30+ days. Use **Settings → Export JSON** to capture versioned backups or **Import JSON** to restore.
+- CSV export is available in Settings for quick sharing, but remember that personal mode has no cross-device sync yet—you’ll need to import your JSON backup on another device manually.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A full-stack web app to track, organize, and analyze job applications — and th
 - Status history tracking (every status change is logged)
 - Enhanced analytics (based on full status history, not just current state)
 - Multi-mode support: Admin (API), Personal (IndexedDB), and Demo (sessionStorage) with onboarding chooser
-- Mode badge and contextual messaging so visitors always know which mode they are using
+- Mode badge, inline banners, and backup reminders so visitors always know which mode they are using, how data is stored, and how to stay safe
 - Loading spinner during backend startup (Render cold start)
 - React frontend communicates with FastAPI backend using Axios
 - Backend stores jobs in a PostgreSQL database using SQLAlchemy ORM
@@ -51,8 +51,8 @@ A full-stack web app to track, organize, and analyze job applications — and th
 
 ## Modes
 
-- **Personal (Local)** — When no `?key=` is present and you choose *Personal* on first launch, JobLog stores everything privately in IndexedDB. Changes persist across browser sessions, you can export/import JSON backups, and nothing is synced or uploaded.
-- **Public Demo** — Also available without a key. Choose *Demo* to load a curated dataset (dates dynamically align with “last 7 days” for believable analytics). Data lives in `sessionStorage`, so it disappears when the tab closes or when you hit Reset Demo.
+- **Personal (Local)** — When no `?key=` is present and you choose *Personal* on first launch, JobLog stores everything privately in IndexedDB. Changes persist across browser sessions, you can export/import JSON backups, and nothing is synced or uploaded. Dismissible reminders keep users aware of backup best practices.
+- **Public Demo** — Also available without a key. Choose *Demo* to load a curated dataset (dates dynamically align with “last 7 days” for believable analytics). Data lives in `sessionStorage`, so it disappears when the tab closes or when you hit Reset Demo. A dashed amber banner reinforces that the data is ephemeral.
 - **Admin (Private)** — Visiting with a valid `?key=...` keeps the original server-backed behavior: FastAPI, PostgreSQL, and all real data. This is how the private production instance continues to track 250+ applications.
 
 An onboarding modal guides first-time visitors without keys. You can revisit the choice from the Settings drawer.
@@ -60,7 +60,7 @@ An onboarding modal guides first-time visitors without keys. You can revisit the
 ### Privacy & Backups
 
 - Local/Demo modes never fire axios/fetch calls; they only interact with browser storage.
-- Personal mode offers a backup reminder if you haven’t exported in 30+ days. Use **Settings → Export JSON** to capture versioned backups or **Import JSON** to restore.
+- Personal mode offers a backup reminder if you haven’t exported in 30+ days. Use **Settings → Export JSON** to capture versioned backups or **Import JSON** to restore, and you can re-show the reminder anytime from Settings.
 - CSV export is available in Settings for quick sharing, but remember that personal mode has no cross-device sync yet—you’ll need to import your JSON backup on another device manually.
 
 ## Tech Stack

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "axios": "^1.9.0",
         "chart.js": "^4.4.9",
+        "localforage": "^1.10.0",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -2541,6 +2543,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2744,6 +2752,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -2758,6 +2775,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4071,6 +4097,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,11 @@
   "dependencies": {
     "axios": "^1.9.0",
     "chart.js": "^4.4.9",
+    "localforage": "^1.10.0",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,10 @@ import JobForm from "./components/JobForm";
 import JobList from "./components/JobList";
 import ApplicationTrends from "./components/ApplicationTrends";
 import DemoBanner from "./components/DemoBanner";
+import OnboardingModal from "./components/OnboardingModal";
+import ModeBadge from "./components/ModeBadge";
+import { useMode } from "./context/ModeContext";
+import { MODES } from "./storage/selectStore";
 import mockJobs from "./mock/jobs.sample.json";
 
 const DEMO_STORAGE_KEY = "joblog_demo_state_v1";
@@ -172,11 +176,8 @@ function App() {
     return localStorage.getItem("darkMode") === "true";
   }); // New state for dark mode
 
-  // Extract API key from URL query string
-  const params = new URLSearchParams(window.location.search);
-  const apiKey = params.get("key");
-  const hasAdminKey = Boolean(apiKey);
-  const isDemo = !hasAdminKey;
+  const { mode, apiKey, hasAdmin, needsOnboarding, setMode } = useMode();
+  const isDemo = mode !== MODES.ADMIN;
 
   const handleJobAdded = (newJob) => {
     setJobs((prev) => [...prev, newJob]);
@@ -221,7 +222,7 @@ function App() {
   };
 
   useEffect(() => {
-    if (hasAdminKey) {
+    if (hasAdmin) {
       setLoading(true);
       axios
         .get(
@@ -238,7 +239,7 @@ function App() {
     const demoJobs = loadDemoJobs();
     setJobs(demoJobs);
     setLoading(false);
-  }, [hasAdminKey, apiKey]);
+  }, [hasAdmin, apiKey]);
 
   useEffect(() => {
     if (darkMode) {
@@ -263,8 +264,11 @@ function App() {
   return (
     <div className="min-h-screen bg-light-background text-light-text dark:bg-dark-background dark:text-dark-text dark:font-mono p-8 transition-colors duration-500 ease-in-out">
       <div className="bg-light-card dark:bg-dark-card rounded-xl shadow-sm p-6 mb-6 transition-colors duration-500">
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-bold">Job Log</h1>
+        <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold">Job Log</h1>
+            <ModeBadge />
+          </div>
           <button
             onClick={() => setDarkMode(!darkMode)}
             className="text-sm border px-3 py-1 rounded border-light-accent dark:border-dark-accent hover:bg-light-accent hover:text-white dark:hover:bg-dark-card dark:hover:shadow-[0_0_10px_#22d3ee] transition focus:outline-none focus:ring-2 focus:ring-light-accent dark:focus:ring-dark-accent"
@@ -292,6 +296,7 @@ function App() {
         onDemoDelete={handleDemoDelete}
       />
 
+      <OnboardingModal open={needsOnboarding} onSelect={setMode} />
     </div>
   );
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -432,8 +432,8 @@ function App() {
               onClick={() => setDarkMode(!darkMode)}
               className={`text-sm border px-3 py-1 rounded transition focus:outline-none focus:ring-2 focus:ring-light-accent dark:focus:ring-dark-accent ${
                 darkMode
-                  ? "border-dark-accent text-dark-text bg-dark-card hover:shadow-[0_0_14px_#22d3ee]"
-                  : "border-light-accent text-light-text hover:bg-light-accent hover:text-white"
+                  ? "border-dark-accent text-dark-accent hover:text-white hover:bg-dark-card dark:hover:border-dark-accent dark:hover:shadow-[0_0_14px_#22d3ee]"
+                  : "border-light-accent text-light-accent hover:bg-light-accent hover:text-white"
               }`}
             >
               {darkMode ? "Light Mode" : "Dark Mode"}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -480,6 +480,10 @@ function App() {
         onExportCsv={handleExportCsv}
         onClearData={handleClearData}
         reminder={backupReminder}
+        onShowPersonalReminder={() => {
+          setShowPersonalBanner(true);
+          localStorage.removeItem("joblog_personal_banner_hidden_v1");
+        }}
       />
       <OnboardingModal open={needsOnboarding} onSelect={setMode} />
     </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -449,6 +449,11 @@ function App() {
         open={settingsOpen}
         onClose={() => setSettingsOpen(false)}
         mode={mode}
+        onSelectMode={(nextMode) => {
+          if (nextMode && nextMode !== mode) {
+            setMode(nextMode);
+          }
+        }}
         onExportJson={handleExportJson}
         onImportJson={handleImportJson}
         onExportCsv={handleExportCsv}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -139,7 +139,10 @@ function App() {
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [darkMode, setDarkMode] = useState(() => {
-    return localStorage.getItem("darkMode") === "true";
+    const stored = localStorage.getItem("darkMode");
+    if (stored === "true") return true;
+    if (stored === "false") return false;
+    return true;
   }); // New state for dark mode
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [store, setStore] = useState(null);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -417,7 +417,7 @@ function App() {
           <div className="flex items-center gap-2">
             <button
               onClick={() => setSettingsOpen(true)}
-              className="text-sm border px-3 py-1 rounded border-light-accent text-light-accent transition hover:bg-light-accent hover:text-white focus:outline-none focus:ring-2 focus:ring-light-accent dark:border-dark-accent dark:text-dark-accent dark:hover:bg-dark-card dark:hover:text-white"
+              className="text-sm border px-3 py-1 rounded border-light-accent text-light-accent transition hover:bg-light-accent hover:text-white focus:outline-none focus:ring-2 focus:ring-light-accent dark:border-dark-accent dark:text-dark-accent dark:hover:border-dark-accent dark:hover:bg-dark-card dark:hover:text-white dark:focus:ring-dark-accent"
             >
               Settings
             </button>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -146,40 +146,46 @@ function App() {
   const [lastBackupAt, setLastBackupAt] = useState(null);
 
   const { mode, apiKey, needsOnboarding, setMode } = useMode();
-  const isClientMode = mode !== MODES.ADMIN;
   const isDemoMode = mode === MODES.DEMO;
-  const isLocalMode = mode === MODES.LOCAL;
 
-  const handleJobAdded = (newJob) => {
-    setJobs((prev) => [...prev, newJob]);
-  };
+  const handleCreateJob = useCallback(
+    async (jobPayload) => {
+      if (!store) return null;
+      try {
+        return await store.createJob(jobPayload);
+      } catch (error) {
+        console.error("Failed to create job:", error);
+        throw error;
+      }
+    },
+    [store]
+  );
 
-  const handleDemoAdd = async (job) => {
-    if (!store) return;
-    try {
-      await store.createJob(job);
-    } catch (error) {
-      console.error("Failed to create job in current mode:", error);
-    }
-  };
+  const handleUpdateJob = useCallback(
+    async (id, patch) => {
+      if (!store) return null;
+      try {
+        return await store.updateJob(id, patch);
+      } catch (error) {
+        console.error("Failed to update job:", error);
+        throw error;
+      }
+    },
+    [store]
+  );
 
-  const handleDemoUpdate = async (id, patch) => {
-    if (!store) return;
-    try {
-      await store.updateJob(id, patch);
-    } catch (error) {
-      console.error("Failed to update job in current mode:", error);
-    }
-  };
-
-  const handleDemoDelete = async (id) => {
-    if (!store) return;
-    try {
-      await store.deleteJob(id);
-    } catch (error) {
-      console.error("Failed to delete job in current mode:", error);
-    }
-  };
+  const handleDeleteJob = useCallback(
+    async (id) => {
+      if (!store) return;
+      try {
+        await store.deleteJob(id);
+      } catch (error) {
+        console.error("Failed to delete job:", error);
+        throw error;
+      }
+    },
+    [store]
+  );
 
   const handleResetDemo = async () => {
     if (!store) return;
@@ -427,20 +433,13 @@ function App() {
 
       {isDemoMode && <DemoBanner onReset={handleResetDemo} />}
 
-      <JobForm
-        onJobAdded={handleJobAdded}
-        apiKey={apiKey}
-        demoMode={isClientMode}
-        onDemoAdd={handleDemoAdd}
-      />
+      <JobForm onCreateJob={handleCreateJob} mode={mode} />
       <ApplicationTrends jobs={jobs} />
       <JobList
         jobs={jobs}
-        setJobs={setJobs}
-        apiKey={apiKey}
-        demoMode={isClientMode}
-        onDemoUpdate={handleDemoUpdate}
-        onDemoDelete={handleDemoDelete}
+        mode={mode}
+        onUpdateJob={handleUpdateJob}
+        onDeleteJob={handleDeleteJob}
       />
 
       <SettingsDrawer

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -420,7 +420,7 @@ function App() {
           <div className="flex items-center gap-2">
             <button
               onClick={() => setSettingsOpen(true)}
-              className={`text-sm border px-3 py-1 rounded transition focus:outline-none focus:ring-2 focus:ring-light-accent dark:focus:ring-dark-accent ${
+              className={`text-sm border px-3 py-1 rounded transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-light-accent dark:focus-visible:ring-dark-accent ${
                 darkMode
                   ? "border-dark-accent text-dark-accent hover:bg-dark-card hover:text-white dark:hover:border-dark-accent dark:hover:shadow-[0_0_14px_#22d3ee]"
                   : "border-light-accent text-light-accent hover:bg-light-accent hover:text-white"
@@ -430,7 +430,7 @@ function App() {
             </button>
             <button
               onClick={() => setDarkMode(!darkMode)}
-              className={`text-sm border px-3 py-1 rounded transition focus:outline-none focus:ring-2 focus:ring-light-accent dark:focus:ring-dark-accent ${
+              className={`text-sm border px-3 py-1 rounded transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-light-accent dark:focus-visible:ring-dark-accent ${
                 darkMode
                   ? "border-dark-accent text-dark-accent hover:text-white hover:bg-dark-card dark:hover:border-dark-accent dark:hover:shadow-[0_0_14px_#22d3ee]"
                   : "border-light-accent text-light-accent hover:bg-light-accent hover:text-white"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -420,13 +420,21 @@ function App() {
           <div className="flex items-center gap-2">
             <button
               onClick={() => setSettingsOpen(true)}
-              className="text-sm border px-3 py-1 rounded border-light-accent text-light-accent transition hover:bg-light-accent hover:text-white focus:outline-none focus:ring-2 focus:ring-light-accent dark:border-dark-accent dark:text-dark-accent dark:hover:border-dark-accent dark:hover:bg-dark-card dark:hover:text-white dark:focus:ring-dark-accent"
+              className={`text-sm border px-3 py-1 rounded transition focus:outline-none focus:ring-2 focus:ring-light-accent dark:focus:ring-dark-accent ${
+                darkMode
+                  ? "border-dark-accent text-dark-accent hover:bg-dark-card hover:text-white dark:hover:border-dark-accent dark:hover:shadow-[0_0_14px_#22d3ee]"
+                  : "border-light-accent text-light-accent hover:bg-light-accent hover:text-white"
+              }`}
             >
               Settings
             </button>
             <button
               onClick={() => setDarkMode(!darkMode)}
-              className="text-sm border px-3 py-1 rounded border-light-accent dark:border-dark-accent hover:bg-light-accent hover:text-white dark:hover:bg-dark-card dark:hover:shadow-[0_0_10px_#22d3ee] transition focus:outline-none focus:ring-2 focus:ring-light-accent dark:focus:ring-dark-accent"
+              className={`text-sm border px-3 py-1 rounded transition focus:outline-none focus:ring-2 focus:ring-light-accent dark:focus:ring-dark-accent ${
+                darkMode
+                  ? "border-dark-accent text-dark-text bg-dark-card hover:shadow-[0_0_14px_#22d3ee]"
+                  : "border-light-accent text-light-text hover:bg-light-accent hover:text-white"
+              }`}
             >
               {darkMode ? "Light Mode" : "Dark Mode"}
             </button>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import JobForm from "./components/JobForm";
 import JobList from "./components/JobList";
 import ApplicationTrends from "./components/ApplicationTrends";
 import DemoBanner from "./components/DemoBanner";
+import PersonalBanner from "./components/PersonalBanner";
 import OnboardingModal from "./components/OnboardingModal";
 import ModeBadge from "./components/ModeBadge";
 import { useMode } from "./context/ModeContext";
@@ -147,6 +148,10 @@ function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [store, setStore] = useState(null);
   const [lastBackupAt, setLastBackupAt] = useState(null);
+  const [showPersonalBanner, setShowPersonalBanner] = useState(() => {
+    const stored = localStorage.getItem("joblog_personal_banner_hidden_v1");
+    return stored !== "true";
+  });
 
   const { mode, apiKey, needsOnboarding, setMode } = useMode();
   const isDemoMode = mode === MODES.DEMO;
@@ -443,6 +448,14 @@ function App() {
       </div>
 
       {isDemoMode && <DemoBanner onReset={handleResetDemo} />}
+      {mode === MODES.LOCAL && showPersonalBanner && (
+        <PersonalBanner
+          onDismiss={() => {
+            setShowPersonalBanner(false);
+            localStorage.setItem("joblog_personal_banner_hidden_v1", "true");
+          }}
+        />
+      )}
 
       <JobForm onCreateJob={handleCreateJob} mode={mode} />
       <ApplicationTrends jobs={jobs} />

--- a/frontend/src/components/DemoBanner.jsx
+++ b/frontend/src/components/DemoBanner.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 const DemoBanner = ({ onReset = () => {} }) => (
-  <div className='mb-6 rounded-lg border border-light-accent/40 bg-light-background p-4 text-sm text-light-text shadow-sm dark:border-dark-accent/60 dark:bg-dark-card dark:text-dark-text'>
+  <div className='mb-6 rounded-lg border border-light-accent/35 bg-light-accent/10 p-4 text-sm text-light-accent shadow-sm dark:border-dark-accent/50 dark:bg-dark-card dark:text-dark-accent'>
     <div className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
       <div>
         <p className='font-medium text-light-accent dark:text-dark-accent'>
           Demo data only — personal data hidden for privacy.
         </p>
-        <p className='mt-1 text-xs text-gray-600 dark:text-gray-300'>
+        <p className='mt-1 text-xs text-light-accent/80 dark:text-dark-accent/80'>
           Changes persist locally for this tab using sessionStorage. Reset anytime to restore the bundled sample data.
         </p>
       </div>

--- a/frontend/src/components/DemoBanner.jsx
+++ b/frontend/src/components/DemoBanner.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 
 const DemoBanner = ({ onReset = () => {} }) => (
-  <div className='mb-6 rounded-lg border border-light-accent/35 bg-light-accent/10 p-4 text-sm text-light-accent shadow-sm dark:border-dark-accent/50 dark:bg-dark-card dark:text-dark-accent'>
+  <div className='mb-6 rounded-lg border border-amber-400/60 border-dashed bg-amber-50/70 p-4 text-sm text-amber-700 shadow-sm dark:border-amber-300/60 dark:bg-amber-500/10 dark:text-amber-200'>
     <div className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
       <div>
-        <p className='font-medium text-light-accent dark:text-dark-accent'>
+        <p className='font-medium text-amber-600 dark:text-amber-200'>
           Demo data only — personal data hidden for privacy.
         </p>
-        <p className='mt-1 text-xs text-light-accent/80 dark:text-dark-accent/80'>
+        <p className='mt-1 text-xs text-amber-600/80 dark:text-amber-100/80'>
           Changes persist locally for this tab using sessionStorage. Reset anytime to restore the bundled sample data.
         </p>
       </div>
       <button
         type='button'
         onClick={onReset}
-        className='self-start rounded border border-light-accent px-3 py-1 text-xs font-semibold text-light-accent transition hover:bg-light-accent hover:text-white dark:border-dark-accent dark:text-dark-accent dark:hover:bg-dark-accent dark:hover:text-dark-card'
+        className='self-start rounded border border-amber-500 px-3 py-1 text-xs font-semibold text-amber-600 transition hover:bg-amber-500 hover:text-white dark:border-amber-300 dark:text-amber-200 dark:hover:bg-amber-300 dark:hover:text-amber-900'
       >
         Reset Demo
       </button>

--- a/frontend/src/components/ModeBadge.jsx
+++ b/frontend/src/components/ModeBadge.jsx
@@ -13,7 +13,7 @@ const getStyles = (mode) => {
     case MODES.ADMIN:
       return 'bg-emerald-500/15 text-emerald-600 border border-emerald-500/40 dark:bg-emerald-400/10 dark:text-emerald-300 dark:border-emerald-300/30';
     case MODES.LOCAL:
-      return 'bg-indigo-500/15 text-indigo-600 border border-indigo-500/40 dark:bg-indigo-400/10 dark:text-indigo-200 dark:border-indigo-300/30';
+      return 'bg-light-accent/10 text-light-accent border border-light-accent/40 dark:bg-dark-accent/10 dark:text-dark-accent dark:border-dark-accent/40';
     case MODES.DEMO:
     default:
       return 'bg-light-tag-remoteBg text-light-accent border border-light-accent/40 dark:bg-dark-card dark:text-dark-accent dark:border-dark-accent/40';

--- a/frontend/src/components/ModeBadge.jsx
+++ b/frontend/src/components/ModeBadge.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useMode } from '../context/ModeContext';
+import { MODES } from '../storage/selectStore';
+
+const MODE_LABELS = {
+  [MODES.ADMIN]: 'Admin Mode',
+  [MODES.LOCAL]: 'Personal Mode',
+  [MODES.DEMO]: 'Demo Mode'
+};
+
+const getStyles = (mode) => {
+  switch (mode) {
+    case MODES.ADMIN:
+      return 'bg-emerald-500/15 text-emerald-600 border border-emerald-500/40 dark:bg-emerald-400/10 dark:text-emerald-300 dark:border-emerald-300/30';
+    case MODES.LOCAL:
+      return 'bg-indigo-500/15 text-indigo-600 border border-indigo-500/40 dark:bg-indigo-400/10 dark:text-indigo-200 dark:border-indigo-300/30';
+    case MODES.DEMO:
+    default:
+      return 'bg-light-tag-remoteBg text-light-accent border border-light-accent/40 dark:bg-dark-card dark:text-dark-accent dark:border-dark-accent/40';
+  }
+};
+
+const ModeBadge = ({ className = '' }) => {
+  const { mode } = useMode();
+  const label = MODE_LABELS[mode] ?? MODE_LABELS[MODES.DEMO];
+  const styles = getStyles(mode);
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${styles} ${className}`}
+    >
+      {label}
+    </span>
+  );
+};
+
+export default ModeBadge;

--- a/frontend/src/components/ModeBadge.jsx
+++ b/frontend/src/components/ModeBadge.jsx
@@ -16,7 +16,7 @@ const getStyles = (mode) => {
       return 'bg-light-accent/10 text-light-accent border border-light-accent/40 dark:bg-dark-accent/10 dark:text-dark-accent dark:border-dark-accent/40';
     case MODES.DEMO:
     default:
-      return 'bg-light-tag-remoteBg text-light-accent border border-light-accent/40 dark:bg-dark-card dark:text-dark-accent dark:border-dark-accent/40';
+      return 'bg-amber-400/15 text-amber-600 border border-amber-400/50 dark:bg-amber-400/10 dark:text-amber-200 dark:border-amber-300/40';
   }
 };
 

--- a/frontend/src/components/OnboardingModal.jsx
+++ b/frontend/src/components/OnboardingModal.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { MODES } from '../storage/selectStore';
+
+const optionStyles =
+  'flex flex-col gap-2 rounded-lg border border-light-accent/40 bg-light-background p-4 text-left shadow-sm transition hover:border-light-accent hover:shadow-md focus:outline-none focus:ring-2 focus:ring-light-accent dark:border-dark-accent/40 dark:bg-dark-card dark:text-dark-text dark:hover:border-dark-accent';
+
+const titleStyles = 'text-lg font-semibold';
+const bodyStyles = 'text-sm text-gray-600 dark:text-gray-300';
+const buttonStyles =
+  'mt-2 inline-flex items-center gap-2 self-start rounded bg-light-accent px-3 py-1 text-sm font-semibold text-white transition hover:bg-light-accentHover dark:bg-dark-accent dark:hover:bg-dark-accentHover';
+
+const ModeOption = ({ label, description, actionLabel, onClick }) => (
+  <button className={optionStyles} type='button' onClick={onClick}>
+    <span className={titleStyles}>{label}</span>
+    <span className={bodyStyles}>{description}</span>
+    <span className={buttonStyles}>{actionLabel}</span>
+  </button>
+);
+
+const OnboardingModal = ({ open, onSelect }) => {
+  if (!open) return null;
+
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4'>
+      <div className='w-full max-w-2xl rounded-xl bg-light-card p-6 text-light-text shadow-lg dark:bg-dark-card dark:text-dark-text'>
+        <h2 className='text-2xl font-bold'>Choose how you want to use JobLog</h2>
+        <p className='mt-2 text-sm text-gray-600 dark:text-gray-300'>
+          Pick the mode that fits your workflow. You can change this later in
+          settings.
+        </p>
+        <div className='mt-6 grid gap-4 md:grid-cols-2'>
+          <ModeOption
+            label='Personal (Local)'
+            description='Store applications privately on this device with IndexedDB. Full tracking, exports, and backups without sending data anywhere.'
+            actionLabel='Use personal mode'
+            onClick={() => onSelect(MODES.LOCAL)}
+          />
+          <ModeOption
+            label='Public Demo'
+            description='Explore JobLog with sample data. Try analytics and workflows with no installs. Data resets when you end the session.'
+            actionLabel='Try the demo'
+            onClick={() => onSelect(MODES.DEMO)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OnboardingModal;

--- a/frontend/src/components/PersonalBanner.jsx
+++ b/frontend/src/components/PersonalBanner.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const PersonalBanner = ({ onDismiss }) => (
-  <div className='mb-6 rounded-lg border border-light-accent/35 bg-light-accent/10 px-4 py-3 text-sm text-light-accent shadow-sm dark:border-dark-accent/40 dark:bg-dark-accent/15 dark:text-dark-accent'>
+  <div className='mb-6 rounded-lg border border-light-accent/35 bg-light-accent/10 px-4 py-3 text-sm text-light-accent shadow-sm dark:border-dark-accent/50 dark:bg-dark-card dark:text-dark-accent'>
     <div className='flex items-start justify-between gap-3'>
       <div>
         <p className='font-semibold text-light-accent dark:text-dark-accent'>

--- a/frontend/src/components/PersonalBanner.jsx
+++ b/frontend/src/components/PersonalBanner.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const PersonalBanner = ({ onDismiss }) => (
+  <div className='mb-6 rounded-lg border border-indigo-500/30 bg-indigo-50 px-4 py-3 text-sm text-indigo-700 shadow-sm dark:border-indigo-400/40 dark:bg-indigo-900/20 dark:text-indigo-200'>
+    <div className='flex items-start justify-between gap-3'>
+      <div>
+        <p className='font-semibold text-indigo-600 dark:text-indigo-200'>
+          Personal mode keeps data on this device only.
+        </p>
+        <p className='mt-1 text-xs text-indigo-600/80 dark:text-indigo-100/80'>
+          Export a JSON backup regularly—clearing browser data, using private
+          windows, or switching devices will remove local entries.
+        </p>
+      </div>
+      <button
+        type='button'
+        onClick={onDismiss}
+        className='rounded border border-transparent px-2 py-1 text-xs font-semibold text-indigo-600 transition hover:text-indigo-800 dark:text-indigo-200 dark:hover:text-white'
+      >
+        Dismiss
+      </button>
+    </div>
+  </div>
+);
+
+export default PersonalBanner;

--- a/frontend/src/components/PersonalBanner.jsx
+++ b/frontend/src/components/PersonalBanner.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 const PersonalBanner = ({ onDismiss }) => (
-  <div className='mb-6 rounded-lg border border-indigo-500/30 bg-indigo-50 px-4 py-3 text-sm text-indigo-700 shadow-sm dark:border-indigo-400/40 dark:bg-indigo-900/20 dark:text-indigo-200'>
+  <div className='mb-6 rounded-lg border border-light-accent/35 bg-light-accent/10 px-4 py-3 text-sm text-light-accent shadow-sm dark:border-dark-accent/40 dark:bg-dark-accent/15 dark:text-dark-accent'>
     <div className='flex items-start justify-between gap-3'>
       <div>
-        <p className='font-semibold text-indigo-600 dark:text-indigo-200'>
+        <p className='font-semibold text-light-accent dark:text-dark-accent'>
           Personal mode keeps data on this device only.
         </p>
-        <p className='mt-1 text-xs text-indigo-600/80 dark:text-indigo-100/80'>
+        <p className='mt-1 text-xs text-light-accent/80 dark:text-dark-accent/80'>
           Export a JSON backup regularly—clearing browser data, using private
           windows, or switching devices will remove local entries.
         </p>
@@ -15,7 +15,7 @@ const PersonalBanner = ({ onDismiss }) => (
       <button
         type='button'
         onClick={onDismiss}
-        className='rounded border border-transparent px-2 py-1 text-xs font-semibold text-indigo-600 transition hover:text-indigo-800 dark:text-indigo-200 dark:hover:text-white'
+        className='rounded border border-transparent px-2 py-1 text-xs font-semibold text-light-accent transition hover:bg-light-accent hover:text-white dark:text-dark-accent dark:hover:bg-dark-accent dark:hover:text-white'
       >
         Dismiss
       </button>

--- a/frontend/src/components/SettingsDrawer.jsx
+++ b/frontend/src/components/SettingsDrawer.jsx
@@ -3,7 +3,7 @@ import ModeBadge from './ModeBadge';
 import { MODES } from '../storage/selectStore';
 
 const actionButton =
-  'w-full rounded-lg border border-light-accent/40 bg-light-background px-4 py-3 text-left text-sm font-medium text-light-text shadow-sm transition hover:border-light-accent hover:shadow-md focus:outline-none focus:ring-2 focus:ring-light-accent dark:border-dark-accent/40 dark:bg-dark-card dark:text-dark-text dark:hover:border-dark-accent';
+  'w-full rounded-lg border border-light-accent/40 bg-light-background px-4 py-3 text-left text-sm font-medium text-light-text shadow-sm transition hover:border-light-accent hover:shadow-md focus:outline-none focus:ring-2 focus:ring-light-accent dark:border-dark-accent/40 dark:bg-dark-card dark:text-dark-text dark:hover:border-dark-accent dark:focus:ring-dark-accent';
 
 const disabledButton =
   'opacity-50 cursor-not-allowed hover:shadow-none hover:border-light-accent/40 dark:hover:border-dark-accent/40';
@@ -45,7 +45,7 @@ const SettingsDrawer = ({
         onClick={() => onSelectMode?.(target)}
         className={`${actionButton} ${
           active
-            ? 'border-light-accent bg-light-accent/10 dark:border-dark-accent dark:bg-dark-accent/10'
+            ? 'border-light-accent bg-light-accent/10 dark:border-dark-accent dark:bg-dark-accent/20'
             : ''
         } ${isAdmin ? disabledButton : ''}`}
       >
@@ -168,7 +168,7 @@ const SettingsDrawer = ({
             onClick={triggerImport}
             className={`${actionButton} ${
               isAdmin ? disabledButton : ''
-            } flex flex-col`}
+            }`}
             disabled={isAdmin}
           >
             Import JSON backup
@@ -211,7 +211,9 @@ const SettingsDrawer = ({
             type='button'
             onClick={onClearData}
             className={`${actionButton} ${
-              isAdmin ? disabledButton : 'border-red-400/50 hover:border-red-400'
+              isAdmin
+                ? disabledButton
+                : 'border-red-400/50 hover:border-red-400 dark:border-red-300/50 dark:hover:border-red-300'
             }`}
             disabled={isAdmin}
           >

--- a/frontend/src/components/SettingsDrawer.jsx
+++ b/frontend/src/components/SettingsDrawer.jsx
@@ -17,7 +17,8 @@ const SettingsDrawer = ({
   onImportJson,
   onExportCsv,
   onClearData,
-  reminder
+  reminder,
+  onShowPersonalReminder = () => {}
 }) => {
   const fileInputRef = useRef(null);
   const [importState, setImportState] = useState({ status: 'idle', message: '' });
@@ -239,6 +240,15 @@ const SettingsDrawer = ({
             clearing browser data, using private windows, or switching devices
             will remove local entries unless you restore from a backup.
           </p>
+        )}
+        {isLocal && (
+          <button
+            type='button'
+            onClick={onShowPersonalReminder}
+            className='mt-2 inline-flex items-center text-xs font-semibold text-light-accent transition hover:text-white hover:bg-light-accent dark:text-dark-accent dark:hover:text-white dark:hover:bg-dark-accent rounded px-2 py-1'
+          >
+            Show reminder banner again
+          </button>
         )}
       </div>
     </div>

--- a/frontend/src/components/SettingsDrawer.jsx
+++ b/frontend/src/components/SettingsDrawer.jsx
@@ -92,8 +92,11 @@ const SettingsDrawer = ({
   if (!open) return null;
 
   return (
-    <div className='fixed inset-0 z-40 flex justify-end bg-black/40'>
-      <div className='h-full w-full max-w-md overflow-y-auto bg-light-card p-6 text-light-text shadow-xl dark:bg-dark-card dark:text-dark-text'>
+    <div className='fixed inset-0 z-40 flex justify-end bg-black/40' onClick={onClose}>
+      <div
+        className='h-full w-full max-w-md overflow-y-auto bg-light-card p-6 text-light-text shadow-xl dark:bg-dark-card dark:text-dark-text'
+        onClick={(event) => event.stopPropagation()}
+      >
         <div className='flex items-start justify-between gap-4'>
           <div>
             <h2 className='text-xl font-bold'>Settings &amp; Backups</h2>

--- a/frontend/src/components/SettingsDrawer.jsx
+++ b/frontend/src/components/SettingsDrawer.jsx
@@ -109,8 +109,8 @@ const SettingsDrawer = ({
           </button>
         </div>
 
-        <div className='mt-4 flex items-center justify-between rounded-lg bg-light-background px-4 py-3 text-sm shadow-inner dark:bg-dark-background'>
-          <ModeBadge />
+        <div className='mt-4 flex items-center justify-between gap-4 rounded-lg bg-light-background px-4 py-3 text-sm shadow-inner dark:bg-dark-background'>
+          <ModeBadge className='shrink-0' />
           <span className='text-xs text-gray-600 dark:text-gray-300'>
             {modeDescription}
           </span>
@@ -213,7 +213,7 @@ const SettingsDrawer = ({
             className={`${actionButton} ${
               isAdmin
                 ? disabledButton
-                : 'border-red-400/50 hover:border-red-400 dark:border-red-300/50 dark:hover:border-red-300'
+                : 'border-red-400/70 hover:border-red-500 focus:ring-red-400 dark:border-red-400/60 dark:hover:border-red-300 dark:focus:ring-red-400'
             }`}
             disabled={isAdmin}
           >

--- a/frontend/src/components/SettingsDrawer.jsx
+++ b/frontend/src/components/SettingsDrawer.jsx
@@ -12,6 +12,7 @@ const SettingsDrawer = ({
   open,
   onClose,
   mode,
+  onSelectMode,
   onExportJson,
   onImportJson,
   onExportCsv,
@@ -34,6 +35,34 @@ const SettingsDrawer = ({
     }
     return 'Demo data is stored in sessionStorage and resets when you end the session.';
   }, [isAdmin, isLocal]);
+
+  const ModeSwitchButton = ({ target, title, description }) => {
+    const active = mode === target;
+    return (
+      <button
+        type='button'
+        disabled={active}
+        onClick={() => onSelectMode?.(target)}
+        className={`${actionButton} ${
+          active
+            ? 'border-light-accent bg-light-accent/10 dark:border-dark-accent dark:bg-dark-accent/10'
+            : ''
+        } ${isAdmin ? disabledButton : ''}`}
+      >
+        <div className='flex items-center justify-between'>
+          <span className='font-semibold'>{title}</span>
+          {active && (
+            <span className='text-xs uppercase text-light-accent dark:text-dark-accent'>
+              Active
+            </span>
+          )}
+        </div>
+        <p className='mt-1 text-xs font-normal text-gray-500 dark:text-gray-300'>
+          {description}
+        </p>
+      </button>
+    );
+  };
 
   const triggerImport = () => {
     if (!fileInputRef.current) return;
@@ -86,6 +115,24 @@ const SettingsDrawer = ({
             {modeDescription}
           </span>
         </div>
+
+        {!isAdmin && (
+          <div className='mt-6 space-y-3'>
+            <p className='text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-300'>
+              Choose mode
+            </p>
+            <ModeSwitchButton
+              target={MODES.LOCAL}
+              title='Personal (Local)'
+              description='Store data privately in IndexedDB with full read/write access and backups.'
+            />
+            <ModeSwitchButton
+              target={MODES.DEMO}
+              title='Public Demo'
+              description='Use curated sample data backed by sessionStorage. Resets on close.'
+            />
+          </div>
+        )}
 
         {reminder ? (
           <div className='mt-4 rounded-lg border border-amber-400/60 bg-amber-50 p-4 text-sm text-amber-700 dark:border-amber-300/60 dark:bg-amber-900/20 dark:text-amber-200'>

--- a/frontend/src/components/SettingsDrawer.jsx
+++ b/frontend/src/components/SettingsDrawer.jsx
@@ -235,8 +235,9 @@ const SettingsDrawer = ({
         )}
         {isLocal && (
           <p className='mt-4 text-xs text-gray-500 dark:text-gray-300'>
-            Personal mode never sends data to a server. Keep regular exports so
-            you can restore from backups if you change devices.
+            Personal mode never sends data to a server. Export JSON regularly—
+            clearing browser data, using private windows, or switching devices
+            will remove local entries unless you restore from a backup.
           </p>
         )}
       </div>

--- a/frontend/src/components/SettingsDrawer.jsx
+++ b/frontend/src/components/SettingsDrawer.jsx
@@ -1,0 +1,195 @@
+import React, { useMemo, useRef, useState } from 'react';
+import ModeBadge from './ModeBadge';
+import { MODES } from '../storage/selectStore';
+
+const actionButton =
+  'w-full rounded-lg border border-light-accent/40 bg-light-background px-4 py-3 text-left text-sm font-medium text-light-text shadow-sm transition hover:border-light-accent hover:shadow-md focus:outline-none focus:ring-2 focus:ring-light-accent dark:border-dark-accent/40 dark:bg-dark-card dark:text-dark-text dark:hover:border-dark-accent';
+
+const disabledButton =
+  'opacity-50 cursor-not-allowed hover:shadow-none hover:border-light-accent/40 dark:hover:border-dark-accent/40';
+
+const SettingsDrawer = ({
+  open,
+  onClose,
+  mode,
+  onExportJson,
+  onImportJson,
+  onExportCsv,
+  onClearData,
+  reminder
+}) => {
+  const fileInputRef = useRef(null);
+  const [importState, setImportState] = useState({ status: 'idle', message: '' });
+
+  const isAdmin = mode === MODES.ADMIN;
+  const isDemo = mode === MODES.DEMO;
+  const isLocal = mode === MODES.LOCAL;
+
+  const modeDescription = useMemo(() => {
+    if (isAdmin) {
+      return 'Connected to the live backend with full read/write access.';
+    }
+    if (isLocal) {
+      return 'Personal data lives privately in IndexedDB on this device.';
+    }
+    return 'Demo data is stored in sessionStorage and resets when you end the session.';
+  }, [isAdmin, isLocal]);
+
+  const triggerImport = () => {
+    if (!fileInputRef.current) return;
+    fileInputRef.current.click();
+  };
+
+  const handleFileChange = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      await onImportJson?.(text);
+      setImportState({
+        status: 'success',
+        message: `Imported ${file.name} successfully.`
+      });
+    } catch (error) {
+      setImportState({
+        status: 'error',
+        message: error?.message || 'Import failed. Please verify the file.'
+      });
+    } finally {
+      event.target.value = '';
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className='fixed inset-0 z-40 flex justify-end bg-black/40'>
+      <div className='h-full w-full max-w-md overflow-y-auto bg-light-card p-6 text-light-text shadow-xl dark:bg-dark-card dark:text-dark-text'>
+        <div className='flex items-start justify-between gap-4'>
+          <div>
+            <h2 className='text-xl font-bold'>Settings &amp; Backups</h2>
+            <p className='mt-1 text-xs text-gray-600 dark:text-gray-300'>
+              Manage how JobLog stores your data.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className='rounded border border-transparent px-3 py-1 text-sm text-gray-500 transition hover:text-gray-700 dark:text-gray-300 dark:hover:text-white'
+          >
+            Close
+          </button>
+        </div>
+
+        <div className='mt-4 flex items-center justify-between rounded-lg bg-light-background px-4 py-3 text-sm shadow-inner dark:bg-dark-background'>
+          <ModeBadge />
+          <span className='text-xs text-gray-600 dark:text-gray-300'>
+            {modeDescription}
+          </span>
+        </div>
+
+        {reminder ? (
+          <div className='mt-4 rounded-lg border border-amber-400/60 bg-amber-50 p-4 text-sm text-amber-700 dark:border-amber-300/60 dark:bg-amber-900/20 dark:text-amber-200'>
+            <p className='font-semibold'>{reminder.title}</p>
+            <p className='mt-1 text-xs'>{reminder.message}</p>
+            {reminder.actionLabel && reminder.onAction && (
+              <button
+                type='button'
+                onClick={reminder.onAction}
+                className='mt-3 inline-flex items-center rounded bg-amber-500 px-3 py-1 text-xs font-semibold text-white transition hover:bg-amber-400 dark:bg-amber-400 dark:text-amber-900 dark:hover:bg-amber-300'
+              >
+                {reminder.actionLabel}
+              </button>
+            )}
+          </div>
+        ) : null}
+
+        <div className='mt-6 space-y-3'>
+          <button
+            type='button'
+            onClick={onExportJson}
+            className={`${actionButton} ${isAdmin ? disabledButton : ''}`}
+            disabled={isAdmin}
+          >
+            Export JSON snapshot
+            <p className='mt-1 text-xs font-normal text-gray-500 dark:text-gray-300'>
+              Save a versioned backup of your applications.
+            </p>
+          </button>
+
+          <button
+            type='button'
+            onClick={triggerImport}
+            className={`${actionButton} ${
+              isAdmin ? disabledButton : ''
+            } flex flex-col`}
+            disabled={isAdmin}
+          >
+            Import JSON backup
+            <p className='mt-1 text-xs font-normal text-gray-500 dark:text-gray-300'>
+              Replace the current dataset with a previously exported backup.
+            </p>
+          </button>
+          <input
+            ref={fileInputRef}
+            type='file'
+            accept='application/json'
+            onChange={handleFileChange}
+            className='hidden'
+          />
+          {importState.status !== 'idle' && (
+            <p
+              className={`text-xs ${
+                importState.status === 'error'
+                  ? 'text-red-500'
+                  : 'text-emerald-500'
+              }`}
+            >
+              {importState.message}
+            </p>
+          )}
+
+          <button
+            type='button'
+            onClick={onExportCsv}
+            className={actionButton}
+          >
+            Export CSV
+            <p className='mt-1 text-xs font-normal text-gray-500 dark:text-gray-300'>
+              Download the current view as a spreadsheet for sharing or
+              analysis.
+            </p>
+          </button>
+
+          <button
+            type='button'
+            onClick={onClearData}
+            className={`${actionButton} ${
+              isAdmin ? disabledButton : 'border-red-400/50 hover:border-red-400'
+            }`}
+            disabled={isAdmin}
+          >
+            Clear current data
+            <p className='mt-1 text-xs font-normal text-gray-500 dark:text-gray-300'>
+              Remove all records from this mode. This cannot be undone.
+            </p>
+          </button>
+        </div>
+
+        {isDemo && (
+          <p className='mt-4 text-xs text-gray-500 dark:text-gray-300'>
+            Demo mode resets automatically when you close the tab. Use “Clear
+            current data” to restore the bundled sample dataset sooner.
+          </p>
+        )}
+        {isLocal && (
+          <p className='mt-4 text-xs text-gray-500 dark:text-gray-300'>
+            Personal mode never sends data to a server. Keep regular exports so
+            you can restore from backups if you change devices.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SettingsDrawer;

--- a/frontend/src/context/ModeContext.jsx
+++ b/frontend/src/context/ModeContext.jsx
@@ -1,0 +1,117 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+import { MODES } from '../storage/selectStore';
+
+const STORAGE_KEY = 'joblog_mode_preference_v1';
+
+const ModeContext = createContext({
+  mode: MODES.DEMO,
+  apiKey: null,
+  hasAdmin: false,
+  needsOnboarding: false,
+  setMode: () => {},
+  resetPreference: () => {}
+});
+
+const readStoredMode = () => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+    if ([MODES.DEMO, MODES.LOCAL].includes(stored)) {
+      return stored;
+    }
+    return null;
+  } catch (error) {
+    console.warn('Unable to read stored mode preference:', error);
+    return null;
+  }
+};
+
+const writeStoredMode = (mode) => {
+  if (typeof window === 'undefined') return;
+  try {
+    if (!mode) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, mode);
+    }
+  } catch (error) {
+    console.warn('Unable to persist mode preference:', error);
+  }
+};
+
+export const ModeProvider = ({ children }) => {
+  const params = new URLSearchParams(
+    typeof window !== 'undefined' ? window.location.search : ''
+  );
+  const apiKey = params.get('key');
+  const hasAdmin = Boolean(apiKey);
+
+  const storedMode = useMemo(() => (!hasAdmin ? readStoredMode() : null), [
+    hasAdmin
+  ]);
+
+  const [mode, setModeState] = useState(() => {
+    if (hasAdmin) return MODES.ADMIN;
+    return storedMode ?? MODES.DEMO;
+  });
+
+  const [needsOnboarding, setNeedsOnboarding] = useState(
+    !hasAdmin && !storedMode
+  );
+
+  useEffect(() => {
+    if (hasAdmin) {
+      setModeState(MODES.ADMIN);
+      setNeedsOnboarding(false);
+    }
+  }, [hasAdmin]);
+
+  const setMode = useCallback(
+    (nextMode) => {
+      if (hasAdmin) {
+        console.warn('Cannot override admin mode while API key is present.');
+        return;
+      }
+      if (![MODES.DEMO, MODES.LOCAL].includes(nextMode)) {
+        console.warn('Unsupported mode preference:', nextMode);
+        return;
+      }
+      setModeState(nextMode);
+      writeStoredMode(nextMode);
+      setNeedsOnboarding(false);
+    },
+    [hasAdmin]
+  );
+
+  const resetPreference = useCallback(() => {
+    if (hasAdmin) return;
+    writeStoredMode(null);
+    setNeedsOnboarding(true);
+  }, [hasAdmin]);
+
+  const value = useMemo(
+    () => ({
+      mode,
+      apiKey,
+      hasAdmin,
+      needsOnboarding,
+      setMode,
+      resetPreference
+    }),
+    [apiKey, hasAdmin, mode, needsOnboarding, resetPreference, setMode]
+  );
+
+  return (
+    <ModeContext.Provider value={value}>{children}</ModeContext.Provider>
+  );
+};
+
+export const useMode = () => useContext(ModeContext);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.jsx';
+import { ModeProvider } from './context/ModeContext.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <ModeProvider>
+      <App />
+    </ModeProvider>
+  </StrictMode>
+);

--- a/frontend/src/storage/driver-api.js
+++ b/frontend/src/storage/driver-api.js
@@ -1,0 +1,65 @@
+import axios from 'axios';
+
+const buildQuery = (apiKey) =>
+  apiKey ? `?key=${encodeURIComponent(apiKey)}` : '';
+
+export const createApiDriver = ({ apiKey }) => {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL;
+  if (!baseUrl) {
+    console.warn(
+      'VITE_API_BASE_URL is not defined; admin mode calls may fail.'
+    );
+  }
+
+  const client = axios.create({
+    baseURL: baseUrl
+  });
+
+  const fetchJobs = async () => {
+    const suffix = buildQuery(apiKey);
+    const response = await client.get(`/jobs${suffix}`);
+    return response.data || [];
+  };
+
+  return {
+    async loadJobs() {
+      return fetchJobs();
+    },
+    async createJob(payload) {
+      const query = buildQuery(apiKey);
+      const response = await client.post(`/jobs/${query}`, payload);
+      return response.data;
+    },
+    async updateJob(id, payload) {
+      const query = buildQuery(apiKey);
+      const response = await client.put(`/jobs/${id}${query}`, payload);
+      return response.data;
+    },
+    async deleteJob(id) {
+      const query = buildQuery(apiKey);
+      await client.delete(`/jobs/${id}${query}`);
+    },
+    async reset() {
+      // No reset concept for the API driver.
+    },
+    async clear() {
+      // No-op for API driver.
+    },
+    async exportData() {
+      // Pull fresh data to ensure exported view matches server.
+      return {
+        version: 1,
+        jobs: await fetchJobs()
+      };
+    },
+    async importData() {
+      throw new Error('Import is not supported in admin mode.');
+    },
+    async getMeta() {
+      return null;
+    },
+    async setMeta() {
+      // Metas are not tracked server-side currently.
+    }
+  };
+};

--- a/frontend/src/storage/driver-demo.js
+++ b/frontend/src/storage/driver-demo.js
@@ -1,0 +1,120 @@
+const JOBS_KEY = 'joblog_demo_jobs_v2';
+const META_KEY = 'joblog_demo_meta_v1';
+
+const hasWindow = () => typeof window !== 'undefined';
+
+const generateId = () => Date.now() + Math.floor(Math.random() * 1000);
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const readJobs = (seed) => {
+  if (!hasWindow()) return clone(seed);
+  try {
+    const raw = window.sessionStorage.getItem(JOBS_KEY);
+    if (!raw) return clone(seed);
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : clone(seed);
+  } catch (error) {
+    console.warn('Failed to read demo jobs from sessionStorage:', error);
+    return clone(seed);
+  }
+};
+
+const writeJobs = (jobs) => {
+  if (!hasWindow()) return;
+  try {
+    window.sessionStorage.setItem(JOBS_KEY, JSON.stringify(jobs));
+  } catch (error) {
+    console.warn('Failed to persist demo jobs to sessionStorage:', error);
+  }
+};
+
+const readMeta = () => {
+  if (!hasWindow()) return {};
+  try {
+    const raw = window.sessionStorage.getItem(META_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (error) {
+    console.warn('Failed to read demo meta from sessionStorage:', error);
+    return {};
+  }
+};
+
+const writeMeta = (meta) => {
+  if (!hasWindow()) return;
+  try {
+    window.sessionStorage.setItem(META_KEY, JSON.stringify(meta));
+  } catch (error) {
+    console.warn('Failed to write demo meta to sessionStorage:', error);
+  }
+};
+
+export const createDemoDriver = ({ seed }) => ({
+  async loadJobs() {
+    return readJobs(seed);
+  },
+  async createJob(payload) {
+    const jobs = readJobs(seed);
+    const newJob = {
+      ...payload,
+      id: payload.id ?? generateId()
+    };
+    jobs.push(newJob);
+    writeJobs(jobs);
+    return newJob;
+  },
+  async updateJob(id, payload) {
+    const jobs = readJobs(seed);
+    const index = jobs.findIndex((job) => String(job.id) === String(id));
+    if (index === -1) {
+      throw new Error('Job not found');
+    }
+    const updated = {
+      ...jobs[index],
+      ...payload,
+      id: jobs[index].id
+    };
+    jobs[index] = updated;
+    writeJobs(jobs);
+    return updated;
+  },
+  async deleteJob(id) {
+    const jobs = readJobs(seed);
+    const filtered = jobs.filter((job) => String(job.id) !== String(id));
+    writeJobs(filtered);
+  },
+  async reset() {
+    writeJobs(clone(seed));
+    writeMeta({});
+  },
+  async clear() {
+    if (!hasWindow()) return;
+    try {
+      window.sessionStorage.removeItem(JOBS_KEY);
+      window.sessionStorage.removeItem(META_KEY);
+    } catch (error) {
+      console.warn('Failed to clear demo store from sessionStorage:', error);
+    }
+  },
+  async exportData() {
+    const jobs = readJobs(seed);
+    return {
+      version: 1,
+      jobs
+    };
+  },
+  async importData(bundle) {
+    writeJobs(bundle.jobs);
+  },
+  async getMeta(key) {
+    const meta = readMeta();
+    return meta[key];
+  },
+  async setMeta(key, value) {
+    const meta = readMeta();
+    meta[key] = value;
+    writeMeta(meta);
+  }
+});

--- a/frontend/src/storage/driver-local.js
+++ b/frontend/src/storage/driver-local.js
@@ -1,0 +1,103 @@
+import localforage from 'localforage';
+
+const JOBS_KEY = 'joblog_local_jobs_v1';
+const META_KEY = 'joblog_local_meta_v1';
+
+localforage.config({
+  name: 'joblog',
+  storeName: 'joblog_store',
+  description: 'JobLog local-first storage'
+});
+
+const jobsStore = localforage.createInstance({
+  name: 'joblog',
+  storeName: 'jobs'
+});
+
+const metaStore = localforage.createInstance({
+  name: 'joblog',
+  storeName: 'meta'
+});
+
+const generateId = () => Date.now() + Math.floor(Math.random() * 1000);
+
+const readJobs = async () => {
+  const stored = await jobsStore.getItem(JOBS_KEY);
+  return Array.isArray(stored) ? stored : [];
+};
+
+const writeJobs = async (jobs) => {
+  await jobsStore.setItem(JOBS_KEY, jobs);
+};
+
+const readMeta = async () => {
+  const stored = await metaStore.getItem(META_KEY);
+  return stored && typeof stored === 'object' ? stored : {};
+};
+
+const writeMeta = async (meta) => {
+  await metaStore.setItem(META_KEY, meta);
+};
+
+export const createLocalDriver = () => ({
+  async loadJobs() {
+    return readJobs();
+  },
+  async createJob(payload) {
+    const jobs = await readJobs();
+    const newJob = {
+      ...payload,
+      id: payload.id ?? generateId()
+    };
+    jobs.push(newJob);
+    await writeJobs(jobs);
+    return newJob;
+  },
+  async updateJob(id, payload) {
+    const jobs = await readJobs();
+    const index = jobs.findIndex((job) => String(job.id) === String(id));
+    if (index === -1) {
+      throw new Error('Job not found');
+    }
+    const updated = {
+      ...jobs[index],
+      ...payload,
+      id: jobs[index].id
+    };
+    jobs[index] = updated;
+    await writeJobs(jobs);
+    return updated;
+  },
+  async deleteJob(id) {
+    const jobs = await readJobs();
+    const filtered = jobs.filter((job) => String(job.id) !== String(id));
+    await writeJobs(filtered);
+  },
+  async reset() {
+    // Reset in local mode equates to clearing user data.
+    await writeJobs([]);
+  },
+  async clear() {
+    await writeJobs([]);
+    await writeMeta({});
+  },
+  async exportData() {
+    const jobs = await readJobs();
+    return {
+      version: 1,
+      jobs
+    };
+  },
+  async importData(bundle) {
+    await writeJobs(bundle.jobs);
+  },
+  async getMeta(key) {
+    const meta = await readMeta();
+    return meta[key];
+  },
+  async setMeta(key, value) {
+    const meta = await readMeta();
+    meta[key] = value;
+    await writeMeta(meta);
+  }
+});

--- a/frontend/src/storage/selectStore.js
+++ b/frontend/src/storage/selectStore.js
@@ -1,0 +1,33 @@
+import mockJobs from '../mock/jobs.sample.json';
+import { createStore } from './store';
+import { createApiDriver } from './driver-api';
+import { createLocalDriver } from './driver-local';
+import { createDemoDriver } from './driver-demo';
+
+export const MODES = {
+  ADMIN: 'admin',
+  LOCAL: 'local',
+  DEMO: 'demo'
+};
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+export const createStoreForMode = ({ mode, apiKey, seedJobs }) => {
+  switch (mode) {
+    case MODES.ADMIN: {
+      const driver = createApiDriver({ apiKey });
+      return createStore(driver);
+    }
+    case MODES.LOCAL: {
+      const driver = createLocalDriver();
+      return createStore(driver);
+    }
+    case MODES.DEMO:
+    default: {
+      const driver = createDemoDriver({
+        seed: clone(seedJobs ?? mockJobs)
+      });
+      return createStore(driver);
+    }
+  }
+};

--- a/frontend/src/storage/store.js
+++ b/frontend/src/storage/store.js
@@ -1,0 +1,135 @@
+import { z } from 'zod';
+
+const DATA_VERSION = 1;
+
+export const statusHistorySchema = z
+  .array(
+    z.object({
+      status: z.string(),
+      date: z
+        .string()
+        .regex(
+          /^\d{4}-\d{2}-\d{2}$/,
+          'Dates must be formatted as YYYY-MM-DD'
+        )
+    })
+  )
+  .default([]);
+
+export const jobSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  title: z.string(),
+  company: z.string(),
+  link: z.string().optional().nullable(),
+  notes: z.string().optional().nullable(),
+  tags: z.string().optional().nullable(),
+  date_applied: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Dates must be formatted as YYYY-MM-DD'),
+  status: z.string(),
+  status_history: statusHistorySchema
+});
+
+export const exportBundleSchema = z.object({
+  version: z.literal(DATA_VERSION),
+  jobs: z.array(jobSchema)
+});
+
+const deepClone = (value) => JSON.parse(JSON.stringify(value));
+
+export const createStore = (driver) => {
+  let jobs = [];
+  let initialized = false;
+  const subscribers = new Set();
+
+  const notify = () => {
+    const snapshot = deepClone(jobs);
+    subscribers.forEach((listener) => listener(snapshot));
+  };
+
+  const ensureInitialized = async () => {
+    if (!initialized) {
+      jobs = deepClone(await driver.loadJobs());
+      initialized = true;
+      notify();
+    }
+  };
+
+  return {
+    async load() {
+      await ensureInitialized();
+      return deepClone(jobs);
+    },
+    getSnapshot() {
+      return deepClone(jobs);
+    },
+    subscribe(listener) {
+      subscribers.add(listener);
+      return () => subscribers.delete(listener);
+    },
+    async reload() {
+      jobs = deepClone(await driver.loadJobs());
+      initialized = true;
+      notify();
+      return deepClone(jobs);
+    },
+    async createJob(draft) {
+      await ensureInitialized();
+      const created = await driver.createJob(deepClone(draft));
+      jobs = [...jobs, deepClone(created)];
+      notify();
+      return deepClone(created);
+    },
+    async updateJob(id, updates) {
+      await ensureInitialized();
+      const updated = await driver.updateJob(id, deepClone(updates));
+      jobs = jobs.map((job) =>
+        String(job.id) === String(updated.id) ? deepClone(updated) : job
+      );
+      notify();
+      return deepClone(updated);
+    },
+    async deleteJob(id) {
+      await ensureInitialized();
+      await driver.deleteJob(id);
+      jobs = jobs.filter((job) => String(job.id) !== String(id));
+      notify();
+    },
+    async reset() {
+      await driver.reset?.();
+      return this.reload();
+    },
+    async clear() {
+      await driver.clear?.();
+      jobs = [];
+      notify();
+    },
+    async exportData() {
+      if (!driver.exportData) {
+        throw new Error('Export not supported for this mode');
+      }
+      const bundle = await driver.exportData();
+      return exportBundleSchema.parse(bundle);
+    },
+    async importData(bundle) {
+      if (!driver.importData) {
+        throw new Error('Import not supported for this mode');
+      }
+      const parsed = exportBundleSchema.parse(bundle);
+      await driver.importData(parsed);
+      jobs = deepClone(parsed.jobs);
+      notify();
+      return deepClone(parsed.jobs);
+    },
+    async getMeta(key) {
+      if (!driver.getMeta) return null;
+      return driver.getMeta(key);
+    },
+    async setMeta(key, value) {
+      if (!driver.setMeta) return;
+      await driver.setMeta(key, value);
+    }
+  };
+};
+
+export const DATA_EXPORT_VERSION = DATA_VERSION;


### PR DESCRIPTION
## Summary
- introduce unified storage drivers for admin/api, personal (IndexedDB), and demo (sessionStorage)
- add onboarding modal, mode badge, banners, and personal backup reminder with settings drawer actions
- refactor JobForm/JobList to use the store; tweak UI styling for dark/light parity and clearer demo vs personal cues
- expand README with mode docs and privacy guidance

## Testing
- npm run build
- demo mode add/edit/delete + reset + JSON/CSV export/import
- personal mode add/edit/delete, export JSON, clear + restore from backup, reminder reset
- admin mode smoke test with ?key (create/update/delete against API)
