### PR TITLE
fix: mode-aware analytics heartbeats, per-mode stats, and admin dashboard updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ An onboarding modal guides first-time visitors without keys. You can revisit the
 - Personal mode offers a backup reminder if you haven’t exported in 30+ days. Use **Settings → Export JSON** to capture versioned backups or **Import JSON** to restore, and you can re-show the reminder anytime from Settings.
 - CSV export is available in Settings for quick sharing, but remember that personal mode has no cross-device sync yet—you’ll need to import your JSON backup on another device manually.
 
+## Anonymous Analytics
+
+To understand how JobLog is used (and only when analytics aren’t disabled or blocked by your browser), the app sends a single anonymous “heartbeat” on launch and optional aggregate events. Each browser install gets a random UUID that never leaves the device except as that anonymous identifier.
+
+We collect:
+
+- Install UUID, first/last seen timestamps, current mode (`demo|local|admin`), app version, and a launch counter.
+- Optional aggregate events: `job_create`, `job_update`, `job_delete`, `export_json`, `import_json`.
+
+We **do not** collect job content, company names, personal data, IP addresses, or user-agent strings. Data is never shared outside the JobLog project, and only admin sessions (`?key=...`) can view the aggregate dashboard.
+
+### Opting out
+
+- Analytics are disabled automatically if your browser’s **Do Not Track** / Global Privacy Control setting is enabled.
+- You can toggle telemetry off at any time under **Settings → Disable anonymous analytics**. The toggle persists locally and stops all future heartbeats/events.
+- Want to see the disclosure again? Use the same settings panel to re-show the personal-mode reminder banner.
+
 ## Tech Stack
 
 - **Frontend:** React + Tailwind CSS (Vite)

--- a/backend/main.py
+++ b/backend/main.py
@@ -206,14 +206,26 @@ def analytics_heartbeat(payload: schemas.AnalyticsHeartbeat, db: Session = Depen
         install.mode = payload.mode
         install.version = payload.version
 
+    launch_event = models.AnalyticsEvent(
+        install_id=install_id,
+        event=f"launch_{payload.mode}",
+        ts=seen_at,
+    )
+    db.add(launch_event)
     db.commit()
     return Response(status_code=204)
 
 
 @app.post("/analytics/event", status_code=204)
 def analytics_event(payload: schemas.AnalyticsEventIn, db: Session = Depends(get_db)):
-    if payload.event not in ALLOWED_ANALYTICS_EVENTS:
-        raise HTTPException(status_code=400, detail="Unsupported event type")
+    event_name = payload.event
+    base_event = event_name
+    if event_name not in ALLOWED_ANALYTICS_EVENTS:
+        base_part, sep, suffix = event_name.rpartition("_")
+        if sep and suffix in {"demo", "local", "admin"} and base_part in ALLOWED_ANALYTICS_EVENTS:
+            base_event = base_part
+        else:
+            raise HTTPException(status_code=400, detail="Unsupported event type")
 
     event_ts = _ts_to_datetime(payload.ts)
     event = models.AnalyticsEvent(
@@ -236,90 +248,94 @@ def admin_stats(db: Session = Depends(get_db)):
     active_7d = db.query(models.AnalyticsInstall).filter(models.AnalyticsInstall.last_seen >= seven_days_ago).count()
     active_30d = db.query(models.AnalyticsInstall).filter(models.AnalyticsInstall.last_seen >= thirty_days_ago).count()
     total_launches = db.query(func.coalesce(func.sum(models.AnalyticsInstall.launch_count), 0)).scalar() or 0
-    total_events = db.query(func.count(models.AnalyticsEvent.id)).scalar() or 0
-    jobs_created = db.query(models.AnalyticsEvent).filter(models.AnalyticsEvent.event == "job_create").count()
-    users_exported = db.query(models.AnalyticsEvent).filter(models.AnalyticsEvent.event == "export_json").count()
+    launch_event_names = {f"launch_{m}" for m in ("demo", "local", "admin")}
 
     by_mode = {mode: schemas.ModeBucket() for mode in ("demo", "local", "admin")}
-
-    install_counts = (
-        db.query(models.AnalyticsInstall.mode, func.count(models.AnalyticsInstall.id))
-        .group_by(models.AnalyticsInstall.mode)
+    launch_events = (
+        db.query(models.AnalyticsEvent.event, func.count(models.AnalyticsEvent.id))
+        .filter(models.AnalyticsEvent.event.in_(launch_event_names))
+        .group_by(models.AnalyticsEvent.event)
         .all()
     )
-    for mode, count in install_counts:
-        if mode in by_mode:
-            by_mode[mode].installs = count
+    for event_name, count in launch_events:
+        _, mode_key = event_name.split("_", 1)
+        if mode_key in by_mode:
+            by_mode[mode_key].launches = count
 
-    active7_counts = (
-        db.query(models.AnalyticsInstall.mode, func.count(models.AnalyticsInstall.id))
-        .filter(models.AnalyticsInstall.last_seen >= seven_days_ago)
-        .group_by(models.AnalyticsInstall.mode)
+    launch_installs = (
+        db.query(models.AnalyticsEvent.event, func.count(func.distinct(models.AnalyticsEvent.install_id)))
+        .filter(models.AnalyticsEvent.event.in_(launch_event_names))
+        .group_by(models.AnalyticsEvent.event)
         .all()
     )
-    for mode, count in active7_counts:
-        if mode in by_mode:
-            by_mode[mode].active_7d = count
+    for event_name, count in launch_installs:
+        _, mode_key = event_name.split("_", 1)
+        if mode_key in by_mode:
+            by_mode[mode_key].installs = count
 
-    active30_counts = (
-        db.query(models.AnalyticsInstall.mode, func.count(models.AnalyticsInstall.id))
-        .filter(models.AnalyticsInstall.last_seen >= thirty_days_ago)
-        .group_by(models.AnalyticsInstall.mode)
+    launch_active7 = (
+        db.query(models.AnalyticsEvent.event, func.count(func.distinct(models.AnalyticsEvent.install_id)))
+        .filter(models.AnalyticsEvent.event.in_(launch_event_names))
+        .filter(models.AnalyticsEvent.ts >= seven_days_ago)
+        .group_by(models.AnalyticsEvent.event)
         .all()
     )
-    for mode, count in active30_counts:
-        if mode in by_mode:
-            by_mode[mode].active_30d = count
+    for event_name, count in launch_active7:
+        _, mode_key = event_name.split("_", 1)
+        if mode_key in by_mode:
+            by_mode[mode_key].active_7d = count
 
-    launch_sums = (
-        db.query(models.AnalyticsInstall.mode, func.coalesce(func.sum(models.AnalyticsInstall.launch_count), 0))
-        .group_by(models.AnalyticsInstall.mode)
+    launch_active30 = (
+        db.query(models.AnalyticsEvent.event, func.count(func.distinct(models.AnalyticsEvent.install_id)))
+        .filter(models.AnalyticsEvent.event.in_(launch_event_names))
+        .filter(models.AnalyticsEvent.ts >= thirty_days_ago)
+        .group_by(models.AnalyticsEvent.event)
         .all()
     )
-    for mode, launches in launch_sums:
-        if mode in by_mode:
-            by_mode[mode].launches = int(launches or 0)
+    for event_name, count in launch_active30:
+        _, mode_key = event_name.split("_", 1)
+        if mode_key in by_mode:
+            by_mode[mode_key].active_30d = count
 
-    events_per_mode = (
-        db.query(models.AnalyticsInstall.mode, func.count(models.AnalyticsEvent.id))
-        .join(
-            models.AnalyticsInstall,
-            models.AnalyticsInstall.id == models.AnalyticsEvent.install_id,
-        )
-        .group_by(models.AnalyticsInstall.mode)
+    install_modes = {
+        install_id: mode_value
+        for install_id, mode_value in db.query(models.AnalyticsInstall.id, models.AnalyticsInstall.mode)
+    }
+
+    total_events = 0
+    jobs_created = 0
+    users_exported = 0
+
+    event_rows = (
+        db.query(models.AnalyticsEvent.event, models.AnalyticsEvent.install_id)
+        .filter(~models.AnalyticsEvent.event.in_(launch_event_names))
         .all()
     )
-    for mode, count in events_per_mode:
-        if mode in by_mode:
-            by_mode[mode].events_total = count
 
-    jobs_created_per_mode = (
-        db.query(models.AnalyticsInstall.mode, func.count(models.AnalyticsEvent.id))
-        .join(
-            models.AnalyticsInstall,
-            models.AnalyticsInstall.id == models.AnalyticsEvent.install_id,
-        )
-        .filter(models.AnalyticsEvent.event == "job_create")
-        .group_by(models.AnalyticsInstall.mode)
-        .all()
-    )
-    for mode, count in jobs_created_per_mode:
-        if mode in by_mode:
-            by_mode[mode].jobs_created = count
+    for event_name, install_id in event_rows:
+        base_event = event_name
+        mode_for_event = None
 
-    users_exported_per_mode = (
-        db.query(models.AnalyticsInstall.mode, func.count(models.AnalyticsEvent.id))
-        .join(
-            models.AnalyticsInstall,
-            models.AnalyticsInstall.id == models.AnalyticsEvent.install_id,
-        )
-        .filter(models.AnalyticsEvent.event == "export_json")
-        .group_by(models.AnalyticsInstall.mode)
-        .all()
-    )
-    for mode, count in users_exported_per_mode:
-        if mode in by_mode:
-            by_mode[mode].users_exported = count
+        if event_name in ALLOWED_ANALYTICS_EVENTS:
+            mode_for_event = install_modes.get(install_id)
+        else:
+            base_part, sep, suffix = event_name.rpartition("_")
+            if sep and base_part in ALLOWED_ANALYTICS_EVENTS and suffix in by_mode:
+                base_event = base_part
+                mode_for_event = suffix
+
+        total_events += 1
+        if base_event == "job_create":
+            jobs_created += 1
+        elif base_event == "export_json":
+            users_exported += 1
+
+        if mode_for_event in by_mode:
+            by_mode[mode_for_event].events_total += 1
+            if base_event == "job_create":
+                by_mode[mode_for_event].jobs_created += 1
+            elif base_event == "export_json":
+                by_mode[mode_for_event].users_exported += 1
 
     return schemas.AdminStats(
         unique_installs=unique_installs,

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Date
+from sqlalchemy import Column, Integer, String, Date, DateTime
 from sqlalchemy.dialects.sqlite import JSON
 from database import Base
 
@@ -14,3 +14,23 @@ class Job(Base):
     notes = Column(String)
     tags = Column(String)  # comma-separated values (e.g., "remote,referral")
     status_history = Column(JSON, default=list)
+
+
+class AnalyticsInstall(Base):
+    __tablename__ = "analytics_installs"
+
+    id = Column(String, primary_key=True, index=True)
+    first_seen = Column(DateTime, nullable=False)
+    last_seen = Column(DateTime, nullable=False)
+    launch_count = Column(Integer, default=0, nullable=False)
+    mode = Column(String, nullable=True)
+    version = Column(String, nullable=True)
+
+
+class AnalyticsEvent(Base):
+    __tablename__ = "analytics_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    install_id = Column(String, nullable=False, index=True)
+    event = Column(String, nullable=False)
+    ts = Column(DateTime, nullable=False)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -35,7 +35,7 @@ class AnalyticsHeartbeat(BaseModel):
 
 class AnalyticsEventIn(BaseModel):
     id: UUID
-    event: Literal["job_create", "job_update", "job_delete", "export_json", "import_json"]
+    event: str
     ts: int
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
-from typing import Optional
-from typing import List
+from typing import Optional, List, Literal
+from uuid import UUID
+
 
 class StatusEntry(BaseModel):
     status: str
@@ -23,4 +24,26 @@ class JobOut(JobCreate):
 
     class Config:
         from_attributes = True
-        
+
+
+class AnalyticsHeartbeat(BaseModel):
+    id: UUID
+    mode: Literal["demo", "local", "admin"]
+    version: str
+    ts: int
+
+
+class AnalyticsEventIn(BaseModel):
+    id: UUID
+    event: Literal["job_create", "job_update", "job_delete", "export_json", "import_json"]
+    ts: int
+
+
+class AdminStats(BaseModel):
+    unique_installs: int
+    active_7d: int
+    active_30d: int
+    total_launches: int
+    total_events: int
+    jobs_created: int
+    users_exported: int

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional, List, Literal
+from typing import Optional, List, Literal, Dict
 from uuid import UUID
 
 
@@ -39,6 +39,16 @@ class AnalyticsEventIn(BaseModel):
     ts: int
 
 
+class ModeBucket(BaseModel):
+    installs: int = 0
+    active_7d: int = 0
+    active_30d: int = 0
+    launches: int = 0
+    events_total: int = 0
+    jobs_created: int = 0
+    users_exported: int = 0
+
+
 class AdminStats(BaseModel):
     unique_installs: int
     active_7d: int
@@ -47,3 +57,4 @@ class AdminStats(BaseModel):
     total_events: int
     jobs_created: int
     users_exported: int
+    by_mode: Dict[Literal["demo", "local", "admin"], ModeBucket]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -219,6 +219,12 @@ function App() {
   const effectiveAnalyticsOptOut = analyticsOptOut || doNotTrack;
 
   const sendHeartbeat = useCallback(() => {
+    const context = {
+      mode,
+      effectiveAnalyticsOptOut,
+      apiBaseUrlAvailable: Boolean(API_BASE_URL),
+    };
+    console.debug("analytics: attempting heartbeat", context);
     if (!installId || !API_BASE_URL || effectiveAnalyticsOptOut) return;
     const payload = {
       id: installId,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import DemoBanner from "./components/DemoBanner";
 import PersonalBanner from "./components/PersonalBanner";
 import OnboardingModal from "./components/OnboardingModal";
 import ModeBadge from "./components/ModeBadge";
+import AdminStats from "./components/AdminStats";
 import { useMode } from "./context/ModeContext";
 import { MODES, createStoreForMode } from "./storage/selectStore";
 import SettingsDrawer from "./components/SettingsDrawer";
@@ -609,6 +610,7 @@ function App() {
       </div>
 
       {isDemoMode && <DemoBanner onReset={handleResetDemo} />}
+      {mode === MODES.ADMIN && apiKey && <AdminStats apiKey={apiKey} />}
       {mode === MODES.LOCAL && showPersonalBanner && (
         <PersonalBanner
           onDismiss={() => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -210,9 +210,14 @@ function App() {
     }
   });
   const doNotTrack = useMemo(() => detectDoNotTrack(), []);
+
+  const { mode, apiKey, needsOnboarding, setMode } = useMode();
+  const isDemoMode = mode === MODES.DEMO;
+
   const heartbeatSentRef = useRef(false);
   const previousModeRef = useRef(mode);
   const effectiveAnalyticsOptOut = analyticsOptOut || doNotTrack;
+
   const sendHeartbeat = useCallback(() => {
     if (!installId || !API_BASE_URL || effectiveAnalyticsOptOut) return;
     const payload = {
@@ -240,7 +245,7 @@ function App() {
     } catch (error) {
       console.debug("Unable to send analytics heartbeat", error);
     }
-  }, [installId, effectiveAnalyticsOptOut, mode, API_BASE_URL]);
+  }, [installId, API_BASE_URL, effectiveAnalyticsOptOut, mode]);
 
   const sendAnalyticsEvent = useCallback(
     (eventName) => {
@@ -271,7 +276,7 @@ function App() {
         console.debug("Unable to record analytics event", error);
       }
     },
-    [installId, effectiveAnalyticsOptOut, API_BASE_URL]
+    [installId, API_BASE_URL, effectiveAnalyticsOptOut]
   );
 
   const handleAnalyticsToggle = useCallback((disabled) => {
@@ -285,9 +290,6 @@ function App() {
       heartbeatSentRef.current = false;
     }
   }, []);
-
-  const { mode, apiKey, needsOnboarding, setMode } = useMode();
-  const isDemoMode = mode === MODES.DEMO;
 
   const handleCreateJob = useCallback(
     async (jobPayload) => {
@@ -610,7 +612,9 @@ function App() {
       </div>
 
       {isDemoMode && <DemoBanner onReset={handleResetDemo} />}
+
       {mode === MODES.ADMIN && apiKey && <AdminStats apiKey={apiKey} />}
+
       {mode === MODES.LOCAL && showPersonalBanner && (
         <PersonalBanner
           onDismiss={() => {
@@ -619,15 +623,6 @@ function App() {
           }}
         />
       )}
-
-      <JobForm onCreateJob={handleCreateJob} mode={mode} />
-      <ApplicationTrends jobs={jobs} />
-      <JobList
-        jobs={jobs}
-        mode={mode}
-        onUpdateJob={handleUpdateJob}
-        onDeleteJob={handleDeleteJob}
-      />
 
       <SettingsDrawer
         open={settingsOpen}
@@ -650,6 +645,15 @@ function App() {
         analyticsOptOut={analyticsOptOut}
         doNotTrack={doNotTrack}
         onAnalyticsToggle={handleAnalyticsToggle}
+      />
+
+      <JobForm onCreateJob={handleCreateJob} mode={mode} />
+      <ApplicationTrends jobs={jobs} />
+      <JobList
+        jobs={jobs}
+        mode={mode}
+        onUpdateJob={handleUpdateJob}
+        onDeleteJob={handleDeleteJob}
       />
       <OnboardingModal open={needsOnboarding} onSelect={setMode} />
     </div>

--- a/frontend/src/components/AdminStats.jsx
+++ b/frontend/src/components/AdminStats.jsx
@@ -46,6 +46,13 @@ const AdminStats = ({ apiKey }) => {
 
   if (!apiKey || !API_BASE_URL) return null;
 
+  const modeBuckets = stats?.by_mode;
+  const modeOrder = [
+    { key: 'local', label: 'Personal (Local)' },
+    { key: 'demo', label: 'Public Demo' },
+    { key: 'admin', label: 'Admin' }
+  ];
+
   return (
     <div className='mb-6 rounded-lg border border-light-accent/30 bg-light-background p-4 text-sm text-light-text shadow-sm dark:border-dark-accent/40 dark:bg-dark-card dark:text-dark-text'>
       <div className='mb-4 flex items-center justify-between'>
@@ -74,6 +81,49 @@ const AdminStats = ({ apiKey }) => {
           </div>
         ))}
       </div>
+
+      {modeBuckets && (
+        <div className='mt-8'>
+          <h3 className='mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-300'>
+            By Mode
+          </h3>
+          <div className='grid gap-4 md:grid-cols-3'>
+            {modeOrder.map(({ key, label }) => {
+              const bucket = modeBuckets?.[key] || {};
+              const cells = [
+                { label: 'Installs', value: bucket.installs },
+                { label: 'Active 7d', value: bucket.active_7d },
+                { label: 'Active 30d', value: bucket.active_30d },
+                { label: 'Launches', value: bucket.launches },
+                { label: 'Events', value: bucket.events_total },
+                { label: 'Jobs created', value: bucket.jobs_created },
+                { label: 'Users exported', value: bucket.users_exported }
+              ];
+
+              return (
+                <div
+                  key={key}
+                  className='flex flex-col gap-2 rounded-lg border border-light-accent/20 bg-white/80 p-3 text-left shadow-sm dark:border-dark-accent/25 dark:bg-dark-background'
+                >
+                  <div className='text-sm font-semibold text-light-accent dark:text-dark-accent'>
+                    {label}
+                  </div>
+                  <div className='grid gap-1 text-xs text-gray-600 dark:text-gray-300'>
+                    {cells.map(({ label: cellLabel, value }) => (
+                      <div key={cellLabel} className='flex items-center justify-between'>
+                        <span>{cellLabel}</span>
+                        <span className='font-semibold text-light-text dark:text-dark-text'>
+                          {value?.toLocaleString?.() ?? value ?? 0}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/AdminStats.jsx
+++ b/frontend/src/components/AdminStats.jsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+const STAT_CARDS = [
+  { key: 'unique_installs', label: 'Unique installs' },
+  { key: 'active_7d', label: 'Active last 7 days' },
+  { key: 'active_30d', label: 'Active last 30 days' },
+  { key: 'total_launches', label: 'Total launches' },
+  { key: 'total_events', label: 'Total events' },
+  { key: 'jobs_created', label: 'Jobs created' },
+  { key: 'users_exported', label: 'Users exported' }
+];
+
+const AdminStats = ({ apiKey }) => {
+  const [stats, setStats] = useState(null);
+  const [status, setStatus] = useState('idle');
+
+  useEffect(() => {
+    if (!apiKey || !API_BASE_URL) return;
+    let cancelled = false;
+    setStatus('loading');
+    fetch(`${API_BASE_URL}/admin/stats?key=${encodeURIComponent(apiKey)}`)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load stats: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        if (!cancelled) {
+          setStats(data);
+          setStatus('ready');
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error('Unable to fetch analytics stats:', error);
+          setStatus('error');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiKey]);
+
+  if (!apiKey || !API_BASE_URL) return null;
+
+  return (
+    <div className='mb-6 rounded-lg border border-light-accent/30 bg-light-background p-4 text-sm text-light-text shadow-sm dark:border-dark-accent/40 dark:bg-dark-card dark:text-dark-text'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h2 className='text-lg font-semibold'>Anonymous usage analytics</h2>
+        <span className='rounded-full border border-light-accent px-2 py-1 text-xs font-semibold text-light-accent dark:border-dark-accent dark:text-dark-accent'>
+          Admin only
+        </span>
+      </div>
+      {status === 'error' && (
+        <p className='text-xs text-red-500 dark:text-red-300'>
+          Unable to load analytics right now. Please try again later.
+        </p>
+      )}
+      <div className='grid gap-3 md:grid-cols-2 lg:grid-cols-3'>
+        {STAT_CARDS.map(({ key, label }) => (
+          <div
+            key={key}
+            className='rounded-lg border border-light-accent/25 bg-white/60 p-3 text-center shadow-sm dark:border-dark-accent/30 dark:bg-dark-background'
+          >
+            <div className='text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400'>
+              {label}
+            </div>
+            <div className='mt-2 text-2xl font-semibold text-light-accent dark:text-dark-accent'>
+              {stats ? stats[key]?.toLocaleString?.() ?? stats[key] : status === 'loading' ? '…' : '0'}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AdminStats;

--- a/frontend/src/components/SettingsDrawer.jsx
+++ b/frontend/src/components/SettingsDrawer.jsx
@@ -18,7 +18,10 @@ const SettingsDrawer = ({
   onExportCsv,
   onClearData,
   reminder,
-  onShowPersonalReminder = () => {}
+  onShowPersonalReminder = () => {},
+  analyticsOptOut = false,
+  onAnalyticsToggle = () => {},
+  doNotTrack = false
 }) => {
   const fileInputRef = useRef(null);
   const [importState, setImportState] = useState({ status: 'idle', message: '' });
@@ -26,6 +29,7 @@ const SettingsDrawer = ({
   const isAdmin = mode === MODES.ADMIN;
   const isDemo = mode === MODES.DEMO;
   const isLocal = mode === MODES.LOCAL;
+  const analyticsDisabled = analyticsOptOut || doNotTrack;
 
   const modeDescription = useMemo(() => {
     if (isAdmin) {
@@ -137,6 +141,33 @@ const SettingsDrawer = ({
             />
           </div>
         )}
+
+        <div className='mt-6 rounded-lg border border-light-accent/30 bg-light-background px-4 py-3 text-sm text-light-text shadow-sm dark:border-dark-accent/40 dark:bg-dark-card dark:text-dark-text'>
+          <div className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
+            <div>
+              <p className='font-semibold'>Anonymous analytics</p>
+              <p className='mt-1 text-xs text-gray-500 dark:text-gray-300'>
+                Helps guide future improvements with anonymous install counts. No job
+                data or personal info is ever sent. <a href='#anonymous-analytics' className='underline'>Learn more</a>.
+              </p>
+              {doNotTrack && (
+                <p className='mt-1 text-xs font-semibold text-amber-600 dark:text-amber-300'>
+                  Your browser's Do Not Track setting is enabled, so analytics are already disabled.
+                </p>
+              )}
+            </div>
+            <label className={`flex items-center gap-2 self-start rounded-full border px-3 py-1 text-xs font-semibold transition ${analyticsDisabled ? 'border-amber-400 text-amber-600 dark:border-amber-300 dark:text-amber-200' : 'border-light-accent text-light-accent dark:border-dark-accent dark:text-dark-accent'}`}>
+              <input
+                type='checkbox'
+                className='h-4 w-4 accent-light-accent dark:accent-dark-accent'
+                checked={analyticsOptOut || doNotTrack}
+                onChange={(e) => onAnalyticsToggle(e.target.checked)}
+                disabled={doNotTrack}
+              />
+              Disable analytics
+            </label>
+          </div>
+        </div>
 
         {reminder ? (
           <div className='mt-4 rounded-lg border border-amber-400/60 bg-amber-50 p-4 text-sm text-amber-700 dark:border-amber-300/60 dark:bg-amber-900/20 dark:text-amber-200'>


### PR DESCRIPTION
## Summary
- send analytics heartbeats/events for demo, personal, and admin modes (respecting opt-out + DNT)
- suffix events with mode and update backend aggregation to bucket installs/launches/events per mode
- add AdminStats “By Mode” UI plus opt-out toggle + reminder reset on Settings
- document anonymous analytics flow and opt-out

## Testing
- demo mode: `/analytics/heartbeat` + `job_create_demo`, counts show under “Public Demo”
- personal mode: `/analytics/heartbeat` + `job_create_local`, counts show under “Personal (Local)”
- admin mode: `/analytics/heartbeat` + `job_create_admin`, counts show under “Admin”
- toggled opt-out + browser DNT (analytics suppressed)
- verified blockers (uBlock Origin) can prevent requests; disabling restores telemetry

## Notes
- new tables (`analytics_installs`, `analytics_events`) auto-create via `Base.metadata.create_all`
- job data untouched
