### PR TITLE
Speed up /admin/stats with SQL aggregates and analytics indexes

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -14,3 +14,14 @@ else:
 
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()
+
+
+def ensure_indexes():
+    statements = [
+        "CREATE INDEX IF NOT EXISTS ix_analytics_installs_last_seen ON analytics_installs (last_seen)",
+        "CREATE INDEX IF NOT EXISTS ix_analytics_events_install_id ON analytics_events (install_id)",
+        "CREATE INDEX IF NOT EXISTS ix_analytics_events_event ON analytics_events (event)",
+    ]
+    with engine.begin() as connection:
+        for stmt in statements:
+            connection.exec_driver_sql(stmt)


### PR DESCRIPTION
## Summary
- ensure analytics indexes (events.install_id/event, installs.last_seen) are created at startup so stats queries sit on indexed scans
- replace the Python loops in `/admin/stats` with grouped SQLAlchemy aggregates that preserve the existing response shape
- map per-mode launch/event totals from the aggregate rows into the existing `ModeBucket` buckets

## Testing
- python3 -m compileall backend
- cd backend
  PYTHONPATH=$PWD python - <<'PY'
  from datetime import datetime, timedelta
  import models
  from database import SessionLocal

  session = SessionLocal()
  session.query(models.AnalyticsEvent).delete()
  session.query(models.AnalyticsInstall).delete()
  session.commit()

  modes = ["demo","local","admin"]
  now = datetime.utcnow()

  for i in range(100):
      mode = modes[i % 3]
      install_id = f"seed-{i}"
      install = models.AnalyticsInstall(
          id=install_id,
          first_seen=now - timedelta(days=i % 40),
          last_seen=now - timedelta(days=i % 15),
          launch_count=5,
          mode=mode,
          version="dev",
      )
      session.add(install)
      for j in range(10):
          session.add(models.AnalyticsEvent(
              install_id=install_id,
              event=f"launch_{mode}",
              ts=now - timedelta(hours=j),
          ))
          session.add(models.AnalyticsEvent(
              install_id=install_id,
              event=f"job_create_{mode}",
              ts=now - timedelta(hours=j),
          ))
  session.commit()
  session.close()
  PY
  cd ..
- time curl -s -H "X-Admin-Key: $API_KEY" http://localhost:8000/admin/stats >/tmp/admin-stats.json
- jq '.by_mode' /tmp/admin-stats.json
- sqlite3 backend/jobs.db ".indexes analytics_events"
- sqlite3 backend/jobs.db ".indexes analytics_installs"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database indexes are now created automatically during application initialization for consistent data organization

* **Refactor**
  * Admin statistics queries have been restructured to consolidate multiple separate database operations into unified aggregation patterns, computing analytics metrics simultaneously across data sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->