### PR TITLE
Refactor shared utilities and tighten date validation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -191,12 +191,12 @@ def update_job(job_id: int, updated_job: schemas.JobCreate, db: Session = Depend
         append_date = date_norm or date.today().strftime("%Y-%m-%d")
         if not final_history:
             final_history = []
-        if not any(
+        already_present = any(
             isinstance(entry, dict)
             and entry.get("status") == updated_data["status"]
-            and entry.get("date") == append_date
             for entry in final_history
-        ):
+        )
+        if not already_present:
             final_history.append({"status": updated_data["status"], "date": append_date})
 
     updated_data["status_history"] = final_history

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import { MODES, createStoreForMode } from "./storage/selectStore";
 import SettingsDrawer from "./components/SettingsDrawer";
 import { DATA_EXPORT_VERSION, exportBundleSchema } from "./storage/store";
 import mockJobs from "./mock/jobs.sample.json";
+import { exportJobsToCsv } from "./utils/csv";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const INSTALL_ID_KEY = "joblog_install_id_v1";
@@ -387,33 +388,7 @@ function App() {
   }, [mode, store, sendAnalyticsEvent]);
 
   const handleExportCsv = () => {
-    const headers = [
-      "Title",
-      "Company",
-      "Status",
-      "Date Applied",
-      "Tags",
-      "Notes",
-      "Link",
-    ];
-    const rows = jobs.map((job) => [
-      job.title,
-      job.company,
-      job.status,
-      job.date_applied,
-      job.tags,
-      job.notes?.replace(/\n/g, " "),
-      job.link,
-    ]);
-    const csvContent = [headers, ...rows]
-      .map((row) => row.map((cell) => `"${cell || ""}"`).join(","))
-      .join("\n");
-
-    downloadFile(
-      `joblog-export-${new Date().toISOString().slice(0, 10)}.csv`,
-      csvContent,
-      "text/csv;charset=utf-8;"
-    );
+    exportJobsToCsv(jobs);
   };
 
   const handleImportJson = async (text) => {

--- a/frontend/src/utils/csv.js
+++ b/frontend/src/utils/csv.js
@@ -1,0 +1,40 @@
+const downloadBlob = (content, filename, type) => {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+export const exportJobsToCsv = (jobs, filename = null) => {
+  const headers = [
+    'Title',
+    'Company',
+    'Status',
+    'Date Applied',
+    'Tags',
+    'Notes',
+    'Link'
+  ];
+  const rows = jobs.map((job) => [
+    job.title,
+    job.company,
+    job.status,
+    job.date_applied,
+    job.tags,
+    job.notes?.replace(/\n/g, ' '),
+    job.link
+  ]);
+  const csvContent = [headers, ...rows]
+    .map((row) => row.map((cell) => `"${cell || ''}"`).join(','))
+    .join('\n');
+
+  const name =
+    filename ||
+    `joblog-export-${new Date().toISOString().slice(0, 10)}.csv`;
+  downloadBlob(csvContent, name, 'text/csv;charset=utf-8;');
+};

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -1,0 +1,43 @@
+const PAD = (value) => String(value).padStart(2, '0');
+
+const STRICT_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
+const LOOSE_REGEX = /^(\d{4})-(\d{1,2})-(\d{1,2})$/;
+
+export const todayYMDLocal = () => {
+  const now = new Date();
+  return `${now.getFullYear()}-${PAD(now.getMonth() + 1)}-${PAD(
+    now.getDate()
+  )}`;
+};
+
+export const isValidYMD = (value) => {
+  if (typeof value !== 'string') return false;
+  const match = value.match(STRICT_REGEX);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  );
+};
+
+export const normalizeYMD = (value) => {
+  if (!value || typeof value !== 'string') return '';
+  const match = value.match(LOOSE_REGEX);
+  if (!match) return '';
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const padded = `${year}-${PAD(month)}-${PAD(day)}`;
+  return isValidYMD(padded) ? padded : '';
+};
+
+export const parseYMDToUTC = (value) => {
+  if (!isValidYMD(value)) return 0;
+  const [, year, month, day] = value.match(STRICT_REGEX);
+  return Date.UTC(Number(year), Number(month) - 1, Number(day));
+};

--- a/frontend/src/utils/tags.js
+++ b/frontend/src/utils/tags.js
@@ -1,0 +1,21 @@
+export const parseTags = (value) => {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+};
+
+export const joinTags = (tags) => {
+  if (!Array.isArray(tags)) return '';
+  const seen = new Set();
+  const result = [];
+  for (const tag of tags) {
+    const trimmed = (tag || '').trim();
+    if (trimmed && !seen.has(trimmed)) {
+      seen.add(trimmed);
+      result.push(trimmed);
+    }
+  }
+  return result.join(',');
+};


### PR DESCRIPTION
## Summary
- add shared utilities for dates, tags, and CSV exporting so JobForm, JobList, and App all rely on a single implementation
- enforce real YYYY-MM-DD validation in demo/local modes (both form submit and inline edit); show a friendly message when the date is impossible
- stop the backend from appending duplicate history entries when a status change already includes that status

## Testing
- npm run build (frontend)
- python3 -m compileall backend
- Manual: demo/local job creation rejects 2024-02-31, accepts valid dates, and CSV export downloads correctly from list/settings
- Manual: admin edit from Applied → Offer produces a single dated “Offer” entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form-level error handling with inline error messages
  * Enhanced date validation and handling
  * Improved tag parsing and organization

* **Bug Fixes**
  * Status history deduplication now correctly identifies duplicate entries by status alone
  * CSV export functionality refined for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->