### PR TITLE
feat(list): single-page scroll with sticky controls using react-virtuoso

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Job Log is a privacy-first job application tracker with built-in analytics and t
 
 ---
 
+## Performance
+
+- Single-page scroll: insights, analytics, and job cards all live in the document flow so the browser’s main scrollbar is the only scroll surface.
+- Sticky controls: the search and filter bar stays pinned to the top of the viewport (with the `/` keyboard shortcut) while the rest of the page scrolls away.
+- Window-scrolled virtualization: long lists stream through `react-virtuoso` with `useWindowScroll`, keeping dozens of cards visible without extra containers.
+- `<30` fallback: when a filter returns fewer than 30 jobs we render the simple static list to keep the DOM lightweight for small result sets.
+- CSV export still serialises the full filtered array so downloads match what’s visible, regardless of virtualization.
+
+---
+
 ## Anonymous Analytics
 
 Job Log records only install-level metrics so you can benchmark engagement without exposing PII.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,12 +8,14 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "axios": "^1.9.0",
+        "axios": "^1.12.2",
         "chart.js": "^4.4.9",
+        "form-data": "^4.0.4",
         "localforage": "^1.10.0",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
+        "react-virtuoso": "^4.14.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -2004,12 +2006,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -2956,13 +2959,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -4388,6 +4393,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.14.1.tgz",
+      "integrity": "sha512-NRUF1ak8lY+Tvc6WN9cce59gU+lilzVtOozP+pm9J7iHshLGGjsiAB4rB2qlBPHjFbcXOQpT+7womNHGDUql8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,12 +13,14 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "axios": "^1.9.0",
+    "axios": "^1.12.2",
     "chart.js": "^4.4.9",
+    "form-data": "^4.0.4",
     "localforage": "^1.10.0",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
+    "react-virtuoso": "^4.14.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import JobForm from "./components/JobForm";
 import JobList from "./components/JobList";
-import ApplicationTrends from "./components/ApplicationTrends";
 import DemoBanner from "./components/DemoBanner";
 import PersonalBanner from "./components/PersonalBanner";
 import OnboardingModal from "./components/OnboardingModal";
@@ -252,7 +251,7 @@ function App() {
     } catch (error) {
       console.debug("Unable to send analytics heartbeat", error);
     }
-  }, [installId, API_BASE_URL, effectiveAnalyticsOptOut, mode]);
+  }, [installId, effectiveAnalyticsOptOut, mode]);
 
   const sendAnalyticsEvent = useCallback(
     (eventName) => {
@@ -283,7 +282,7 @@ function App() {
       console.debug("Unable to record analytics event", error);
     }
   },
-    [installId, API_BASE_URL, effectiveAnalyticsOptOut, mode]
+    [installId, effectiveAnalyticsOptOut, mode]
   );
 
   const handleAnalyticsToggle = useCallback((disabled) => {
@@ -402,6 +401,7 @@ function App() {
     try {
       parsed = JSON.parse(text);
     } catch (error) {
+      console.error("Failed to parse imported JSON:", error);
       throw new Error("Invalid JSON: unable to parse file.");
     }
     const bundle = exportBundleSchema.parse(parsed);
@@ -629,7 +629,6 @@ function App() {
       />
 
       <JobForm onCreateJob={handleCreateJob} mode={mode} />
-      <ApplicationTrends jobs={jobs} />
       <JobList
         jobs={jobs}
         mode={mode}

--- a/frontend/src/components/ApplicationTrends.jsx
+++ b/frontend/src/components/ApplicationTrends.jsx
@@ -41,35 +41,11 @@ function getNow() {
 }
 
 const ApplicationTrends = ({ jobs }) => {
-  if (!jobs.length) return null;
-
-  // Generate last 7 days in local timezone (midnight)
-  const last7Days = [...Array(7)].map((_, i) => {
-    const date = getNow();
-    date.setHours(0, 0, 0, 0); // Set to local midnight
-    date.setDate(date.getDate() - (6 - i));
-    return ymdLocal(date);
-  });
-
-  const countsByDate = last7Days.map(
-    (day) => jobs.filter((job) => String(job.date_applied) === day).length
+  const [isDarkMode, setIsDarkMode] = useState(() =>
+    typeof document !== 'undefined'
+      ? document.documentElement.classList.contains('dark')
+      : false
   );
-
-  const [isDarkMode, setIsDarkMode] = useState(
-    document.documentElement.classList.contains('dark')
-  );
-
-  const data = {
-    labels: last7Days,
-    datasets: [
-      {
-        label: 'Applications',
-        data: countsByDate,
-        backgroundColor: isDarkMode ? '#06b6d4' : '#8E9775',
-        hoverBackgroundColor: isDarkMode ? '#22d3ee' : '#7c8667'
-      }
-    ]
-  };
 
   useEffect(() => {
     const observer = new MutationObserver(() => {
@@ -84,15 +60,46 @@ const ApplicationTrends = ({ jobs }) => {
     return () => observer.disconnect();
   }, []);
 
+  // Generate last 7 days in local timezone (midnight)
+  const last7Days = [...Array(7)].map((_, i) => {
+    const date = getNow();
+    date.setHours(0, 0, 0, 0); // Set to local midnight
+    date.setDate(date.getDate() - (6 - i));
+    return ymdLocal(date);
+  });
+
+  const countsByDate = last7Days.map(
+    (day) => jobs.filter((job) => String(job.date_applied) === day).length
+  );
+
+  if (!jobs.length) return null;
+
+  const isMobile = typeof window !== 'undefined' ? window.innerWidth < 640 : false;
+  const aspectRatio = isMobile ? 1.1 : 2.1;
+
+  const data = {
+    labels: last7Days,
+    datasets: [
+      {
+        label: 'Applications',
+        data: countsByDate,
+        backgroundColor: isDarkMode ? '#06b6d4' : '#8E9775',
+        hoverBackgroundColor: isDarkMode ? '#22d3ee' : '#7c8667'
+      }
+    ]
+  };
+
   const options = {
     responsive: true,
+    maintainAspectRatio: true,
+    aspectRatio,
     plugins: {
       legend: { display: false },
       title: {
         display: true,
         text: 'Job Applications - Last 7 Days',
         font: {
-          size: 16,
+          size: isMobile ? 14 : 16,
           weight: 'bold',
           family: isDarkMode ? 'monospace' : undefined
         },
@@ -103,7 +110,7 @@ const ApplicationTrends = ({ jobs }) => {
       x: {
         ticks: {
           color: isDarkMode ? '#e5e7eb' : '#3b3b3b',
-          font: { size: 10, family: isDarkMode ? 'monospace' : undefined }
+          font: { size: isMobile ? 9 : 10, family: isDarkMode ? 'monospace' : undefined }
         },
         grid: {
           color: isDarkMode ? '#e5e7eb' : '#E5E5E0'
@@ -114,7 +121,7 @@ const ApplicationTrends = ({ jobs }) => {
         ticks: {
           stepSize: 1,
           color: isDarkMode ? '#e5e7eb' : '#3b3b3b',
-          font: { size: 10, family: isDarkMode ? 'monospace' : undefined }
+          font: { size: isMobile ? 9 : 10, family: isDarkMode ? 'monospace' : undefined }
         },
         grid: {
           color: isDarkMode ? '#e5e7eb' : '#E5E5E0'
@@ -129,9 +136,21 @@ const ApplicationTrends = ({ jobs }) => {
         'mb-8 bg-[#F9F9F6] dark:bg-[#101010] p-4 rounded shadow' +
         (isDarkMode ? ' font-mono' : '')
       }
-      style={{ height: '300px' }}
+      style={{
+        maxWidth: '48rem',
+        marginLeft: 'auto',
+        marginRight: 'auto'
+      }}
     >
-      <Bar data={data} options={options} />
+      <Bar
+        data={data}
+        options={options}
+        style={{
+          margin: '0 auto',
+          maxWidth: '100%',
+          width: '100%'
+        }}
+      />
     </div>
   );
 };

--- a/frontend/src/components/JobList.jsx
+++ b/frontend/src/components/JobList.jsx
@@ -1,28 +1,46 @@
-/**
- * JobList
- * -------
- * Renders job cards, analytics, filters, CSV export, and inline editing.
- * Key behaviors:
- *  - Sorting: newest days first; within a day, newest entries first (by id).
- *  - Dates: strict YYYY-MM-DD; use local (non-UTC) "today" defaults.
- *  - History: interview rounds are explicit entries; Offer/Rejected capture dated entries.
- *  - Tags: stored CSV; checkboxes drive pill UI and filters.
- *
- * Props
- *  - jobs: array of job records to display.
- *  - mode: current application mode (demo, local, admin).
- *  - onUpdateJob(id, payload, helpers): async handler to persist edits.
- *  - onDeleteJob(id): async handler to remove a job.
- */
-import React, { useState, useMemo, useCallback } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import { Virtuoso } from 'react-virtuoso';
+import ApplicationTrends from './ApplicationTrends';
+import JobRow from './JobRow';
 import { MODES } from '../storage/selectStore';
 import {
-  parseYMDToUTC,
   normalizeYMD,
+  parseYMDToUTC,
   todayYMDLocal
 } from '../utils/date';
-import { parseTags, joinTags } from '../utils/tags';
 import { exportJobsToCsv } from '../utils/csv';
+import { joinTags, parseTags } from '../utils/tags';
+
+const SEARCH_DEBOUNCE_MS = 200;
+const SIMPLE_LIST_THRESHOLD = 30;
+const HIDE_INSIGHTS_KEY = 'joblog_hide_insights';
+
+const safeReadLocalStorage = (key) => {
+  try {
+    return typeof window !== 'undefined'
+      ? window.localStorage.getItem(key)
+      : null;
+  } catch (error) {
+    console.warn(`localStorage read failed for ${key}:`, error);
+    return null;
+  }
+};
+
+const safeWriteLocalStorage = (key, value) => {
+  try {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(key, value);
+    }
+  } catch (error) {
+    console.warn(`localStorage write failed for ${key}:`, error);
+  }
+};
 
 const JobList = ({
   jobs,
@@ -31,6 +49,7 @@ const JobList = ({
   onDeleteJob
 }) => {
   const isAdmin = mode === MODES.ADMIN;
+
   const [editJobId, setEditJobId] = useState(null);
   const [editFormData, setEditFormData] = useState({
     title: '',
@@ -42,28 +61,199 @@ const JobList = ({
     tags: '',
     status_history: []
   });
+  const [roundDelta, setRoundDelta] = useState(0);
+  const [roundAddDate, setRoundAddDate] = useState(todayYMDLocal());
+  const [offerDate, setOfferDate] = useState(todayYMDLocal());
+  const [rejectDate, setRejectDate] = useState(todayYMDLocal());
 
   const [statusFilter, setStatusFilter] = useState('All');
   const [tagFilter, setTagFilter] = useState('All');
-  const tagOptions = [
-    'Remote',
-    'Hybrid',
-    'On-Site',
-    'Referral',
-    'Urgent',
-    'Startup'
-  ];
-  // Planned round delta (applied on Save)
-  const [roundDelta, setRoundDelta] = useState(0);
-  // Date for the round to add
-  const [roundAddDate, setRoundAddDate] = useState(todayYMDLocal());
-  // Optional dates for Offer/Rejected
-  const [offerDate, setOfferDate] = useState(todayYMDLocal());
-  const [rejectDate, setRejectDate] = useState(todayYMDLocal());
+  const [searchValue, setSearchValue] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  const [insightsHidden, setInsightsHidden] = useState(() => {
+    const stored = safeReadLocalStorage(HIDE_INSIGHTS_KEY);
+    return stored === 'true';
+  });
+  const [showScrollTop, setShowScrollTop] = useState(false);
+
+  const searchInputRef = useRef(null);
+  const virtuosoRef = useRef(null);
+
+  const tagOptions = useMemo(
+    () => [
+      'Remote',
+      'Hybrid',
+      'On-Site',
+      'Referral',
+      'Urgent',
+      'Startup'
+    ],
+    []
+  );
+
   const editTags = useMemo(
     () => parseTags(editFormData.tags),
     [editFormData.tags]
   );
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedSearch(searchValue.trim().toLowerCase());
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [searchValue]);
+
+  useEffect(() => {
+    safeWriteLocalStorage(HIDE_INSIGHTS_KEY, insightsHidden ? 'true' : 'false');
+  }, [insightsHidden]);
+
+  useEffect(() => {
+    const handleHotkey = (event) => {
+      if (
+        event.key !== '/' ||
+        event.altKey ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey
+      ) {
+        return;
+      }
+      const target = event.target;
+      const isEditable =
+        target?.isContentEditable ||
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA';
+      if (isEditable) return;
+      event.preventDefault();
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    };
+
+    window.addEventListener('keydown', handleHotkey);
+    return () => window.removeEventListener('keydown', handleHotkey);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handleScroll = () => {
+      setShowScrollTop(window.scrollY > 320);
+    };
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const countInterviewRoundsForJob = useCallback((job) => {
+    return Array.isArray(job?.status_history)
+      ? job.status_history.filter((s) => s.status === 'Interviewing').length
+      : 0;
+  }, []);
+
+  const analytics = useMemo(() => {
+    const totalSubmitted = jobs.length;
+    const pending = jobs.filter((job) => job.status === 'Applied').length;
+
+    const companiesInterviewing = (() => {
+      const set = new Set();
+      for (const job of jobs) {
+        const everInterviewing =
+          job.status === 'Interviewing' ||
+          (Array.isArray(job.status_history) &&
+            job.status_history.some((s) => s.status === 'Interviewing'));
+        if (everInterviewing) set.add(job.company?.trim() || job.id);
+      }
+      return set.size;
+    })();
+
+    const interviewRounds = jobs.reduce(
+      (sum, job) => sum + countInterviewRoundsForJob(job),
+      0
+    );
+
+    const offers = jobs.filter(
+      (job) =>
+        job.status === 'Offer' ||
+        (Array.isArray(job.status_history) &&
+          job.status_history.some((s) => s.status === 'Offer'))
+    ).length;
+
+    const rejections = jobs.filter(
+      (job) =>
+        job.status === 'Rejected' ||
+        (Array.isArray(job.status_history) &&
+          job.status_history.some((s) => s.status === 'Rejected'))
+    ).length;
+
+    const offerRate =
+      totalSubmitted > 0
+        ? `${((offers / totalSubmitted) * 100).toFixed(1)}%`
+        : '0%';
+
+    return {
+      totalSubmitted,
+      pending,
+      companiesInterviewing,
+      interviewRounds,
+      offers,
+      rejections,
+      offerRate
+    };
+  }, [jobs, countInterviewRoundsForJob]);
+
+  const filteredSortedJobs = useMemo(() => {
+    const list = Array.isArray(jobs) ? jobs : [];
+    const searchTerm = debouncedSearch;
+
+    const filtered = list.filter((job) => {
+      const matchesStatus =
+        statusFilter === 'All'
+          ? true
+          : statusFilter === 'Interviewing'
+          ? job.status === 'Interviewing' ||
+            (Array.isArray(job.status_history) &&
+              job.status_history.some((s) => s.status === 'Interviewing'))
+          : job.status === statusFilter;
+      if (!matchesStatus) return false;
+
+      if (tagFilter !== 'All') {
+        if (!job.tags) return false;
+        const tags = parseTags(job.tags);
+        if (!tags.includes(tagFilter)) return false;
+      }
+
+      if (!searchTerm) return true;
+      const haystack = [
+        job.title,
+        job.company,
+        job.notes,
+        job.tags
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(searchTerm);
+    });
+
+    return filtered
+      .slice()
+      .sort((a, b) => {
+        const da = parseYMDToUTC(a.date_applied);
+        const db = parseYMDToUTC(b.date_applied);
+        if (da !== db) {
+          return db - da;
+        }
+        const aid = Number(a.id) || 0;
+        const bid = Number(b.id) || 0;
+        return bid - aid;
+      });
+  }, [jobs, statusFilter, tagFilter, debouncedSearch]);
+
+  const shouldVirtualize = filteredSortedJobs.length >= SIMPLE_LIST_THRESHOLD;
+
+  const handleToggleInsights = useCallback(() => {
+    setInsightsHidden((current) => !current);
+  }, []);
 
   const handleDelete = useCallback(async (id) => {
     try {
@@ -76,6 +266,10 @@ const JobList = ({
     }
   }, [onDeleteJob, isAdmin]);
 
+  const refreshVirtuosoLayout = useCallback(() => {
+    virtuosoRef.current?.refresh();
+  }, []);
+
   const handleEditClick = useCallback((job) => {
     const today = todayYMDLocal();
     setEditJobId(job.id);
@@ -84,31 +278,41 @@ const JobList = ({
     setRoundAddDate(today);
     setOfferDate(today);
     setRejectDate(today);
-  }, []);
+    window.requestAnimationFrame(refreshVirtuosoLayout);
+  }, [refreshVirtuosoLayout]);
 
-  const handleEditChange = useCallback((e) => {
-    const { name, value } = e.target;
+  const handleEditChange = useCallback((event) => {
+    const { name, value } = event.target;
     setEditFormData((prev) => ({ ...prev, [name]: value }));
   }, []);
 
   const handleTagToggle = useCallback((tag) => {
     setEditFormData((prev) => {
       const tags = parseTags(prev.tags);
-      const updated = tags.includes(tag)
-        ? tags.filter((t) => t !== tag)
+      const next = tags.includes(tag)
+        ? tags.filter((value) => value !== tag)
         : [...tags, tag];
-      return { ...prev, tags: joinTags(updated) };
+      return { ...prev, tags: joinTags(next) };
     });
   }, []);
 
+  const handleCancelEdit = useCallback(() => {
+    setEditJobId(null);
+    setRoundDelta(0);
+    setRoundAddDate(todayYMDLocal());
+    setOfferDate(todayYMDLocal());
+    setRejectDate(todayYMDLocal());
+    window.requestAnimationFrame(refreshVirtuosoLayout);
+  }, [refreshVirtuosoLayout]);
+
   const handleSave = useCallback(async () => {
     const original = jobs.find((job) => job.id === editJobId);
-    // Start from the latest server-backed history to avoid stale copies
-    const updatedHistory = Array.isArray(original?.status_history)
+    if (!original) return;
+
+    const updatedHistory = Array.isArray(original.status_history)
       ? [...original.status_history]
       : [...(editFormData.status_history || [])];
 
-    // If status changed, append a dated entry only for non-special statuses (not Interviewing/Offer/Rejected).
     if (editFormData.status !== original.status) {
       if (
         !['Interviewing', 'Offer', 'Rejected'].includes(editFormData.status)
@@ -137,34 +341,32 @@ const JobList = ({
       return;
     }
 
-    // Apply planned interview round changes
     if (roundDelta > 0) {
-      const toAdd = Math.min(1, roundDelta); // at most one per save
-      for (let i = 0; i < toAdd; i++) {
+      const toAdd = Math.min(1, roundDelta);
+      for (let i = 0; i < toAdd; i += 1) {
         const roundDate = ensureDate(roundAddDate, 'Interview round date');
         if (!roundDate && !isAdmin) return;
-        const d = roundDate || todayYMDLocal();
-        updatedHistory.push({ status: 'Interviewing', date: d });
+        updatedHistory.push({
+          status: 'Interviewing',
+          date: roundDate || todayYMDLocal()
+        });
       }
     } else if (roundDelta < 0) {
-      // Remove most recent Interviewing entries, one per "−" press
       let toRemove = Math.min(Math.abs(roundDelta), updatedHistory.length);
       while (toRemove > 0) {
-        // Find the last Interviewing entry from the end
         const idx = [...updatedHistory]
-          .map((h, i) => ({ i, h }))
+          .map((h, index) => ({ index, h }))
           .reverse()
-          .find((x) => x.h.status === 'Interviewing')?.i;
+          .find((entry) => entry.h.status === 'Interviewing')?.index;
         if (idx == null) break;
         updatedHistory.splice(idx, 1);
-        toRemove--;
+        toRemove -= 1;
       }
     }
 
-    // Ensure terminal statuses have a dated history entry (use chosen date, or today)
     if (editFormData.status === 'Offer') {
       const hadOfferBefore =
-        Array.isArray(original?.status_history) &&
+        Array.isArray(original.status_history) &&
         original.status_history.some((s) => s.status === 'Offer');
       const hasOfferNow =
         Array.isArray(updatedHistory) &&
@@ -172,12 +374,14 @@ const JobList = ({
       if (!hadOfferBefore && !hasOfferNow) {
         const normalizedOfferDate = ensureDate(offerDate, 'Offer date');
         if (!normalizedOfferDate && !isAdmin) return;
-        const d = normalizedOfferDate || todayYMDLocal();
-        updatedHistory.push({ status: 'Offer', date: d });
+        updatedHistory.push({
+          status: 'Offer',
+          date: normalizedOfferDate || todayYMDLocal()
+        });
       }
     } else if (editFormData.status === 'Rejected') {
       const hadRejectBefore =
-        Array.isArray(original?.status_history) &&
+        Array.isArray(original.status_history) &&
         original.status_history.some((s) => s.status === 'Rejected');
       const hasRejectNow =
         Array.isArray(updatedHistory) &&
@@ -185,12 +389,13 @@ const JobList = ({
       if (!hadRejectBefore && !hasRejectNow) {
         const normalizedRejectDate = ensureDate(rejectDate, 'Rejection date');
         if (!normalizedRejectDate && !isAdmin) return;
-        const d = normalizedRejectDate || todayYMDLocal();
-        updatedHistory.push({ status: 'Rejected', date: d });
+        updatedHistory.push({
+          status: 'Rejected',
+          date: normalizedRejectDate || todayYMDLocal()
+        });
       }
     }
 
-    // Safeguard: ensure terminal status gets a dated entry.
     if (editFormData.status === 'Offer') {
       const hasOfferFinal =
         Array.isArray(updatedHistory) &&
@@ -198,8 +403,10 @@ const JobList = ({
       if (!hasOfferFinal) {
         const normalizedOfferDate = ensureDate(offerDate, 'Offer date');
         if (!normalizedOfferDate && !isAdmin) return;
-        const d = normalizedOfferDate || todayYMDLocal();
-        updatedHistory.push({ status: 'Offer', date: d });
+        updatedHistory.push({
+          status: 'Offer',
+          date: normalizedOfferDate || todayYMDLocal()
+        });
       }
     } else if (editFormData.status === 'Rejected') {
       const hasRejectFinal =
@@ -208,8 +415,10 @@ const JobList = ({
       if (!hasRejectFinal) {
         const normalizedRejectDate = ensureDate(rejectDate, 'Rejection date');
         if (!normalizedRejectDate && !isAdmin) return;
-        const d = normalizedRejectDate || todayYMDLocal();
-        updatedHistory.push({ status: 'Rejected', date: d });
+        updatedHistory.push({
+          status: 'Rejected',
+          date: normalizedRejectDate || todayYMDLocal()
+        });
       }
     }
 
@@ -238,6 +447,7 @@ const JobList = ({
       setRoundAddDate(todayYMDLocal());
       setOfferDate(todayYMDLocal());
       setRejectDate(todayYMDLocal());
+      window.requestAnimationFrame(refreshVirtuosoLayout);
     } catch (error) {
       console.error('Error updating job:', error);
       if (isAdmin) {
@@ -253,497 +463,279 @@ const JobList = ({
     offerDate,
     rejectDate,
     isAdmin,
-    onUpdateJob
+    onUpdateJob,
+    refreshVirtuosoLayout
   ]);
 
-  // ---- ANALYTICS (renamed + refined) ----
-  // ---- ANALYTICS ----
-  const totalSubmitted = jobs.length;
+  const handleExportCsv = useCallback(() => {
+    exportJobsToCsv(filteredSortedJobs, 'job_applications.csv');
+  }, [filteredSortedJobs]);
 
-  // Pending = currently waiting (status is Applied). Equivalent to Submitted - (current Interviewing + Offer + Rejected)
-  const pending = jobs.filter((job) => job.status === 'Applied').length;
-
-  // Companies interviewed (distinct)
-  const companiesInterviewing = (() => {
-    const set = new Set();
-    for (const job of jobs) {
-      const everInterviewing =
-        job.status === 'Interviewing' ||
-        (Array.isArray(job.status_history) &&
-          job.status_history.some((s) => s.status === 'Interviewing'));
-      if (everInterviewing) set.add(job.company?.trim() || job.id);
-    }
-    return set.size;
-  })();
-
-  // Count interview rounds per job (history only)
-  const countInterviewRoundsForJob = (job) => {
-    return Array.isArray(job.status_history)
-      ? job.status_history.filter((s) => s.status === 'Interviewing').length
-      : 0;
-  };
-
-  // Total interview rounds (sum of Interviewing entries)
-  const interviewRounds = jobs.reduce(
-    (sum, job) => sum + countInterviewRoundsForJob(job),
-    0
-  );
-
-  const offers = jobs.filter(
-    (job) =>
-      job.status === 'Offer' ||
-      (Array.isArray(job.status_history) &&
-        job.status_history.some((s) => s.status === 'Offer'))
-  ).length;
-
-  const rejections = jobs.filter(
-    (job) =>
-      job.status === 'Rejected' ||
-      (Array.isArray(job.status_history) &&
-        job.status_history.some((s) => s.status === 'Rejected'))
-  ).length;
-
-  const offerRate =
-    totalSubmitted > 0
-      ? `${((offers / totalSubmitted) * 100).toFixed(1)}%`
-      : '0%';
-
-  const filteredSortedJobs = useMemo(() => {
-    const list = Array.isArray(jobs) ? jobs : [];
-    const filtered = list.filter((job) => {
-      const matchesStatus =
-        statusFilter === 'All'
-          ? true
-          : statusFilter === 'Interviewing'
-          ? job.status === 'Interviewing' ||
-            (Array.isArray(job.status_history) &&
-              job.status_history.some((s) => s.status === 'Interviewing'))
-          : job.status === statusFilter;
-      if (!matchesStatus) return false;
-      if (tagFilter === 'All') return true;
-      return job.tags ? parseTags(job.tags).includes(tagFilter) : false;
+  const handleScrollTop = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.requestAnimationFrame(() => {
+      const input = searchInputRef.current;
+      if (!input) return;
+      try {
+        input.focus({ preventScroll: true });
+      } catch {
+        input.focus();
+      }
     });
+  }, []);
 
-    return filtered
-      .slice()
-      .sort((a, b) => {
-        const da = parseYMDToUTC(a.date_applied);
-        const db = parseYMDToUTC(b.date_applied);
-        if (da !== db) {
-          return db - da;
-        }
-        const aid = Number(a.id) || 0;
-        const bid = Number(b.id) || 0;
-        return bid - aid;
-      });
-  }, [jobs, statusFilter, tagFilter]);
+  const renderVirtualRow = useCallback((index, job) => {
+    if (!job) return null;
+    const isLast = index === filteredSortedJobs.length - 1;
+    return (
+      <div className={isLast ? '' : 'pb-3 md:pb-4'}>
+        <JobRow
+          job={job}
+          isVirtualized
+          isEditing={job.id === editJobId}
+          editFormData={editFormData}
+          editTags={editTags}
+          roundDelta={roundDelta}
+          roundAddDate={roundAddDate}
+          offerDate={offerDate}
+          rejectDate={rejectDate}
+          tagOptions={tagOptions}
+          onEditChange={handleEditChange}
+          onTagToggle={handleTagToggle}
+          onSave={handleSave}
+          onCancel={handleCancelEdit}
+          onEditClick={handleEditClick}
+          onDelete={handleDelete}
+          setRoundDelta={setRoundDelta}
+          setRoundAddDate={setRoundAddDate}
+          setOfferDate={setOfferDate}
+          setRejectDate={setRejectDate}
+          countInterviewRoundsForJob={countInterviewRoundsForJob}
+        />
+      </div>
+    );
+  }, [
+    editJobId,
+    editFormData,
+    editTags,
+    roundDelta,
+    roundAddDate,
+    offerDate,
+    rejectDate,
+    tagOptions,
+    handleEditChange,
+    handleTagToggle,
+    handleSave,
+    handleCancelEdit,
+    handleEditClick,
+    handleDelete,
+    countInterviewRoundsForJob,
+    filteredSortedJobs.length
+  ]);
 
   return (
-    <div className='p-4 dark:bg-dark-background'>
-      <h2 className='text-xl font-bold mb-4 dark:text-dark-text'>
-        Job Applications
-      </h2>
+    <section className='px-4 pb-12'>
+      <div className='max-w-6xl mx-auto'>
+        <h2 className='text-xl font-bold mb-4 dark:text-dark-text'>
+          Job Applications
+        </h2>
 
-      {/* Analytics */}
-      <div className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-6 text-center'>
-        <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
-          <div className='text-sm text-light-text dark:text-dark-text'>
-            Submitted
+        <div className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between mb-4'>
+          <div className='text-lg font-semibold dark:text-dark-text'>
+            Insights
           </div>
-          <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
-            {totalSubmitted}
-          </div>
+          <button
+            onClick={handleToggleInsights}
+            className='text-sm border px-3 py-1 rounded transition bg-light-background dark:bg-dark-card dark:text-dark-text border-light-accent dark:border-dark-accent hover:bg-light-accent hover:text-white dark:hover:bg-dark-accent dark:hover:text-dark-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-light-accent dark:focus-visible:ring-dark-accent'
+            aria-pressed={!insightsHidden}
+          >
+            {insightsHidden ? 'Show insights' : 'Hide insights'}
+          </button>
         </div>
-        <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
-          <div className='text-sm text-light-text dark:text-dark-text'>
-            Pending
-          </div>
-          <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
-            {pending}
-          </div>
-        </div>
-        <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
-          <div className='text-sm text-light-text dark:text-dark-text'>
-            Interviewed Companies
-          </div>
-          <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
-            {companiesInterviewing}
-          </div>
-        </div>
-        <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
-          <div className='text-sm text-light-text dark:text-dark-text'>
-            Interview Rounds
-          </div>
-          <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
-            {interviewRounds}
-          </div>
-        </div>
-        <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
-          <div className='text-sm text-light-text dark:text-dark-text'>
-            Offers
-          </div>
-          <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
-            {offers}
-          </div>
-        </div>
-        <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
-          <div className='text-sm text-light-text dark:text-dark-text'>
-            Rejected
-          </div>
-          <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
-            {rejections}
-          </div>
-        </div>
-      </div>
 
-      {/* Keep Offer Rate as a separate single card below (optional) */}
-      <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded text-center mb-6'>
-        <div className='text-sm text-light-text dark:text-dark-text'>
-          Offer Rate
-        </div>
-        <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
-          {offerRate}
-        </div>
-      </div>
+        {!insightsHidden && (
+          <div className='space-y-6 mb-6'>
+            <ApplicationTrends jobs={jobs} />
 
-      {/* Filters */}
-      <div className='mb-4'>
-        <label className='font-semibold mr-2 dark:text-dark-text'>
-          Filter by status:
-        </label>
-        <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value)}
-          className='p-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white'
-        >
-          <option value='All'>All</option>
-          <option value='Applied'>Applied</option>
-          <option value='Interviewing'>Interview</option>
-          <option value='Offer'>Offer</option>
-          <option value='Rejected'>Rejected</option>
-        </select>
-      </div>
-
-      <div className='mb-4'>
-        <label className='font-semibold mr-2 dark:text-dark-text'>
-          Filter by tag:
-        </label>
-        <select
-          value={tagFilter}
-          onChange={(e) => setTagFilter(e.target.value)}
-          className='p-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white'
-        >
-          <option value='All'>All</option>
-          {tagOptions.map((tag) => (
-            <option key={tag} value={tag}>
-              {tag}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* CSV Export */}
-      <div className='mb-4'>
-        <button
-          onClick={() => exportJobsToCsv(jobs, 'job_applications.csv')}
-          className='bg-light-accent text-white px-4 py-2 rounded hover:bg-light-accentHover transition dark:bg-cyan-500 dark:hover:bg-cyan-400 dark:hover:shadow-[0_0_10px_#22d3ee]'
-        >
-          Export to CSV
-        </button>
-      </div>
-
-      <ul className='space-y-2'>
-        {filteredSortedJobs.map((job) => (
-            <li
-              key={job.id}
-              className='p-4 border rounded shadow bg-light-background dark:bg-dark-card dark:border-dark-accent text-left'
-            >
-              <div className='flex justify-between items-start'>
-                {editJobId === job.id ? (
-                  <div className='w-full space-y-2'>
-                    <select
-                      name='status'
-                      value={editFormData.status}
-                      onChange={handleEditChange}
-                      className='p-2 border rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-white'
-                    >
-                      <option value='Applied'>Applied</option>
-                      <option value='Interviewing'>Interview</option>
-                      <option value='Offer'>Offer</option>
-                      <option value='Rejected'>Rejected</option>
-                    </select>
-                    {editFormData.status === 'Offer' && (
-                      <div className='flex items-center gap-2'>
-                        <span className='text-xs text-gray-600 dark:text-gray-300'>
-                          Offer date:
-                        </span>
-                        <input
-                          type='date'
-                          value={offerDate}
-                          onChange={(e) => setOfferDate(e.target.value)}
-                          className='text-xs p-1 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white'
-                        />
-                      </div>
-                    )}
-                    {editFormData.status === 'Rejected' && (
-                      <div className='flex items-center gap-2'>
-                        <span className='text-xs text-gray-600 dark:text-gray-300'>
-                          Rejection date:
-                        </span>
-                        <input
-                          type='date'
-                          value={rejectDate}
-                          onChange={(e) => setRejectDate(e.target.value)}
-                          className='text-xs p-1 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white'
-                        />
-                      </div>
-                    )}
-                    {/* Interview round delta controls */}
-                    <div className='flex items-center gap-2 flex-wrap'>
-                      <span className='text-xs text-gray-600 dark:text-gray-300'>
-                        Interview Round:
-                      </span>
-                      <button
-                        type='button'
-                        onClick={() => setRoundDelta(roundDelta - 1)}
-                        className='text-xs px-2 py-1 rounded border dark:border-gray-600 dark:text-dark-text hover:bg-gray-100 dark:hover:bg-gray-700'
-                        title='Remove last interview entry'
-                        aria-label='Remove last interview entry'
-                      >
-                        −
-                      </button>
-                      <button
-                        type='button'
-                        onClick={() =>
-                          setRoundDelta(Math.min(1, roundDelta + 1))
-                        }
-                        className='text-xs px-2 py-1 rounded border dark:border-gray-600 dark:text-dark-text hover:bg-gray-100 dark:hover:bg-gray-700'
-                        title='Plan to add one interview entry'
-                        aria-label='Plan to add one interview entry'
-                      >
-                        +
-                      </button>
-                      <span className='text-xs text-gray-600 dark:text-gray-300'>
-                        :{' '}
-                        {roundDelta > 0
-                          ? `+${Math.min(1, roundDelta)}`
-                          : roundDelta}
-                      </span>
-                      <span className='text-xs text-gray-600 dark:text-gray-300 ml-2'>
-                        on
-                      </span>
-                      <input
-                        type='date'
-                        value={roundAddDate}
-                        onChange={(e) => setRoundAddDate(e.target.value)}
-                        className='text-xs p-1 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white'
-                        title='Date for the interview round to add'
-                      />
-                      {(() => {
-                        // Build a descending list of existing Interviewing dates from the edit form snapshot
-                        const datesDesc = Array.isArray(
-                          editFormData.status_history
-                        )
-                          ? editFormData.status_history
-                              .filter(
-                                (s) => s.status === 'Interviewing' && s.date
-                              )
-                              .map((s) => s.date)
-                              .sort((a, b) => (a < b ? 1 : a > b ? -1 : 0))
-                          : [];
-                        if (roundDelta < 0) {
-                          const n = Math.min(
-                            Math.abs(roundDelta),
-                            datesDesc.length
-                          );
-                          if (n > 0) {
-                            const first = datesDesc[0];
-                            return (
-                              <span className='text-[11px] text-gray-600 dark:text-gray-400 ml-2'>
-                                Removing: {first}
-                                {n > 1 ? ` (+${n - 1} more)` : ''}
-                              </span>
-                            );
-                          }
-                          return (
-                            <span className='text-[11px] text-gray-600 dark:text-gray-400 ml-2'>
-                              Nothing to remove
-                            </span>
-                          );
-                        } else if (roundDelta > 0) {
-                          return (
-                            <span className='text-[11px] text-gray-600 dark:text-gray-400 ml-2'>
-                              Adding on: {roundAddDate}
-                            </span>
-                          );
-                        }
-                        return null;
-                      })()}
-                    </div>
-                    <textarea
-                      name='notes'
-                      value={editFormData.notes}
-                      onChange={handleEditChange}
-                      className='w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white'
-                      rows={3}
-                    />
-                    <div className='flex flex-wrap gap-4'>
-                      {tagOptions.map((tag) => (
-                        <label
-                          key={tag}
-                          className='flex items-center space-x-2 dark:text-dark-text'
-                        >
-                          <input
-                            type='checkbox'
-                            checked={editTags.includes(tag)}
-                            onChange={() => handleTagToggle(tag)}
-                            className='dark:bg-gray-700'
-                          />
-                          <span>{tag}</span>
-                        </label>
-                      ))}
-                    </div>
-                    <div className='space-x-2'>
-                      <button
-                        onClick={handleSave}
-                        className='bg-green-500 text-white px-2 py-1 rounded dark:bg-cyan-500 dark:hover:bg-cyan-400'
-                      >
-                        Save
-                      </button>
-                      <button
-                        onClick={() => {
-                          setEditJobId(null);
-                          setRoundDelta(0);
-                          const todayReset = todayYMDLocal();
-                          setRoundAddDate(todayReset);
-                          setOfferDate(todayReset);
-                          setRejectDate(todayReset);
-                        }}
-                        className='bg-gray-400 text-white px-2 py-1 rounded dark:bg-cyan-800 dark:hover:bg-cyan-900'
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  <>
-                    <div className='flex-1'>
-                      <div className='font-semibold dark:text-dark-text'>
-                        {job.title} @ {job.company}
-                      </div>
-                      <div className='text-sm text-light-accent hover:underline underline break-all dark:text-dark-accent dark:hover:text-dark-accentHover'>
-                        <a
-                          href={job.link}
-                          target='_blank'
-                          rel='noopener noreferrer'
-                          title={job.link}
-                        >
-                          {job.link.length > 60
-                            ? `${job.link.slice(0, 60)}...`
-                            : job.link}
-                        </a>
-                      </div>
-                      <div className='dark:text-dark-text'>
-                        Status: {job.status}
-                      </div>
-                      {job.status_history?.length > 0 && (
-                        <div className='text-xs text-gray-500 mt-1 dark:text-dark-text'>
-                          {job.status_history.map((s, i) => (
-                            <div key={i}>
-                              {s.status === 'Interviewing'
-                                ? 'Interviewed'
-                                : s.status === 'Offer'
-                                ? 'Offered'
-                                : s.status}{' '}
-                              on {s.date}
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                      {/* Interview round count (pluralized; hidden when 0) */}
-                      {(() => {
-                        const rounds = countInterviewRoundsForJob(job);
-                        if (rounds < 1) return null;
-                        const label = `Interview Round${
-                          rounds === 1 ? '' : 's'
-                        }: `;
-                        return (
-                          <div className='text-xs text-gray-500 mt-1 dark:text-dark-text'>
-                            {label}
-                            {rounds}
-                          </div>
-                        );
-                      })()}
-                      <div className='text-gray-700 dark:text-dark-text'>
-                        Notes: {job.notes}
-                      </div>
-                      {job.tags && (
-                        <div className='mt-2 flex flex-wrap gap-2'>
-                          {job.tags.split(',').map((tag, index) => {
-                            let bgClass = 'bg-gray-100';
-                            let textClass = 'text-gray-800';
-                            if (tag.trim() === 'Remote') {
-                              bgClass =
-                                'bg-light-tag-remoteBg text-light-tag-remoteText dark:bg-dark-tag-bg dark:text-dark-tag-text';
-                              textClass = '';
-                            } else if (tag.trim() === 'Hybrid') {
-                              bgClass =
-                                'bg-light-tag-remoteBg text-light-tag-remoteText dark:bg-dark-tag-bg dark:text-dark-tag-text';
-                              textClass = '';
-                            } else if (tag.trim() === 'On-Site') {
-                              bgClass =
-                                'bg-light-tag-remoteBg text-light-tag-remoteText dark:bg-dark-tag-bg dark:text-dark-tag-text';
-                              textClass = '';
-                            } else if (tag.trim() === 'Referral') {
-                              bgClass =
-                                'bg-light-tag-referralBg text-light-tag-referralText dark:bg-dark-tag-bg dark:text-dark-tag-text';
-                              textClass = '';
-                            } else if (tag.trim() === 'Urgent') {
-                              bgClass =
-                                'bg-light-tag-urgentBg text-light-tag-urgentText dark:bg-dark-tag-bg dark:text-dark-tag-text';
-                              textClass = '';
-                            } else if (tag.trim() === 'Startup') {
-                              bgClass =
-                                'bg-light-tag-startupBg text-light-tag-startupText dark:bg-dark-tag-bg dark:text-dark-tag-text';
-                              textClass = '';
-                            }
-                            return (
-                              <span
-                                key={index}
-                                className={`${bgClass} ${textClass} text-xs font-semibold px-2 py-1 rounded`}
-                              >
-                                {tag.trim()}
-                              </span>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </div>
-                    <div className='space-y-2 text-right'>
-                      <button
-                        onClick={() => handleEditClick(job)}
-                        className='text-white px-2 py-1 rounded mr-2 
-                          bg-light-accent hover:bg-light-accentHover 
-                          dark:bg-cyan-500 dark:hover:bg-cyan-400 dark:hover:shadow-[0_0_10px_#22d3ee]'
-                      >
-                        Edit
-                      </button>
-                      <button
-                        onClick={() => handleDelete(job.id)}
-                        className='px-2 py-1 rounded 
-                          text-white bg-red-400 hover:bg-red-500 
-                          dark:bg-red-600 dark:hover:bg-red-500 dark:hover:shadow-[0_0_10px_#f87171]'
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  </>
-                )}
+            <div className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 text-center'>
+              <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
+                <div className='text-sm text-light-text dark:text-dark-text'>
+                  Submitted
+                </div>
+                <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
+                  {analytics.totalSubmitted}
+                </div>
               </div>
-            </li>
-          ))}
-      </ul>
-    </div>
+              <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
+                <div className='text-sm text-light-text dark:text-dark-text'>
+                  Pending
+                </div>
+                <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
+                  {analytics.pending}
+                </div>
+              </div>
+              <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
+                <div className='text-sm text-light-text dark:text-dark-text'>
+                  Interviewed Companies
+                </div>
+                <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
+                  {analytics.companiesInterviewing}
+                </div>
+              </div>
+              <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
+                <div className='text-sm text-light-text dark:text-dark-text'>
+                  Interview Rounds
+                </div>
+                <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
+                  {analytics.interviewRounds}
+                </div>
+              </div>
+              <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
+                <div className='text-sm text-light-text dark:text-dark-text'>
+                  Offers
+                </div>
+                <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
+                  {analytics.offers}
+                </div>
+              </div>
+              <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded'>
+                <div className='text-sm text-light-text dark:text-dark-text'>
+                  Rejected
+                </div>
+                <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
+                  {analytics.rejections}
+                </div>
+              </div>
+            </div>
+
+            <div className='bg-light-background dark:bg-dark-card dark:border dark:border-dark-accent p-3 rounded text-center'>
+              <div className='text-sm text-light-text dark:text-dark-text'>
+                Offer Rate
+              </div>
+              <div className='text-xl font-semibold text-light-text dark:text-dark-text'>
+                {analytics.offerRate}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className='sticky top-0 z-30 mt-6 bg-light-background/95 dark:bg-dark-card/95 backdrop-blur border border-light-muted dark:border-dark-accent rounded-lg shadow-sm px-3 py-3 md:px-4 md:py-4 flex flex-col gap-3 md:gap-4'>
+          <div className='flex flex-col gap-3 sm:flex-row sm:items-end md:items-center md:justify-between'>
+            <label className='flex-1 flex flex-col gap-1 md:max-w-sm'>
+              <span className='text-xs font-medium text-gray-500 dark:text-gray-300 md:text-sm md:text-inherit md:text-gray-900 dark:md:text-dark-text'>
+                Search (press /)
+              </span>
+              <input
+                ref={searchInputRef}
+                type='search'
+                value={searchValue}
+                onChange={(event) => setSearchValue(event.target.value)}
+                placeholder='Title, company, notes, tags'
+                className='w-full p-2 border rounded text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-light-accent dark:focus-visible:ring-dark-accent md:text-base'
+              />
+            </label>
+            <button
+              onClick={handleExportCsv}
+              className='w-full sm:w-auto px-3 py-2 bg-light-accent text-white rounded text-sm hover:bg-light-accentHover transition dark:bg-cyan-500 dark:hover:bg-cyan-400 dark:hover:shadow-[0_0_10px_#22d3ee] sm:self-end md:self-auto md:text-base'
+            >
+              Export filtered CSV
+            </button>
+          </div>
+
+          <div className='grid grid-cols-2 gap-2 sm:gap-3 md:flex md:items-center md:justify-between md:gap-4'>
+            <label className='flex flex-col gap-1 text-xs font-semibold dark:text-dark-text col-span-1 md:text-sm md:flex-row md:items-center md:gap-2 md:col-auto'>
+              <span>Status</span>
+              <select
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value)}
+                className='w-full p-2 border rounded text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-light-accent dark:focus-visible:ring-dark-accent md:text-base'
+              >
+                <option value='All'>All</option>
+                <option value='Applied'>Applied</option>
+                <option value='Interviewing'>Interview</option>
+                <option value='Offer'>Offer</option>
+                <option value='Rejected'>Rejected</option>
+              </select>
+            </label>
+
+            <label className='flex flex-col gap-1 text-xs font-semibold dark:text-dark-text col-span-1 md:text-sm md:flex-row md:items-center md:gap-2 md:col-auto'>
+              <span>Tag</span>
+              <select
+                value={tagFilter}
+                onChange={(event) => setTagFilter(event.target.value)}
+                className='w-full p-2 border rounded text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-light-accent dark:focus-visible:ring-dark-accent md:text-base'
+              >
+                <option value='All'>All</option>
+                {tagOptions.map((tag) => (
+                  <option key={tag} value={tag}>
+                    {tag}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className='col-span-2 text-xs text-gray-600 dark:text-gray-300 md:col-auto md:ml-auto md:text-sm'>
+              Showing {filteredSortedJobs.length} result
+              {filteredSortedJobs.length === 1 ? '' : 's'}
+            </div>
+          </div>
+        </div>
+
+        <div className='mt-6 space-y-4'>
+          {shouldVirtualize ? (
+            <Virtuoso
+              ref={virtuosoRef}
+              useWindowScroll
+              data={filteredSortedJobs}
+              itemContent={renderVirtualRow}
+              increaseViewportBy={{ top: 400, bottom: 400 }}
+            />
+          ) : (
+            <ul className='space-y-3 md:space-y-4'>
+              {filteredSortedJobs.map((job) => (
+                <JobRow
+                  key={job.id}
+                  job={job}
+                  isVirtualized={false}
+                  isEditing={job.id === editJobId}
+                  editFormData={editFormData}
+                  editTags={editTags}
+                  roundDelta={roundDelta}
+                  roundAddDate={roundAddDate}
+                  offerDate={offerDate}
+                  rejectDate={rejectDate}
+                  tagOptions={tagOptions}
+                  onEditChange={handleEditChange}
+                  onTagToggle={handleTagToggle}
+                  onSave={handleSave}
+                  onCancel={handleCancelEdit}
+                  onEditClick={handleEditClick}
+                  onDelete={handleDelete}
+                  setRoundDelta={setRoundDelta}
+                  setRoundAddDate={setRoundAddDate}
+                  setOfferDate={setOfferDate}
+                  setRejectDate={setRejectDate}
+                  countInterviewRoundsForJob={countInterviewRoundsForJob}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {showScrollTop && (
+        <button
+          type='button'
+          onClick={handleScrollTop}
+          className='fixed bottom-5 right-4 h-10 w-10 md:h-11 md:w-11 rounded-full bg-light-accent text-white text-xl md:text-2xl leading-none shadow-lg transition hover:bg-light-accentHover focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-light-accent/60 dark:bg-cyan-500 dark:hover:bg-cyan-400 dark:focus-visible:ring-cyan-400/60'
+          style={{ zIndex: 1000 }}
+          aria-label='Jump to top'
+        >
+          ^
+        </button>
+      )}
+    </section>
   );
 };
 

--- a/frontend/src/components/JobRow.jsx
+++ b/frontend/src/components/JobRow.jsx
@@ -1,0 +1,301 @@
+import React, { memo, useRef } from 'react';
+
+const JobRow = memo(({
+  job,
+  isVirtualized,
+  isEditing,
+  editFormData,
+  editTags,
+  roundDelta,
+  roundAddDate,
+  offerDate,
+  rejectDate,
+  tagOptions,
+  onEditChange,
+  onTagToggle,
+  onSave,
+  onCancel,
+  onEditClick,
+  onDelete,
+  setRoundDelta,
+  setRoundAddDate,
+  setOfferDate,
+  setRejectDate,
+  countInterviewRoundsForJob,
+}) => {
+  const containerRef = useRef(null);
+  const safeTags = Array.isArray(editTags) ? editTags : [];
+  const showOfferDate = editFormData?.status === 'Offer';
+  const showRejectDate = editFormData?.status === 'Rejected';
+
+  const OuterTag = isVirtualized ? 'div' : 'li';
+  const outerProps = isVirtualized
+    ? {
+        ref: containerRef,
+        role: 'listitem'
+      }
+    : {
+        ref: containerRef,
+        className: 'list-none mb-3 last:mb-0'
+      };
+
+  return (
+    <OuterTag {...outerProps}>
+      <div
+        className='p-4 border rounded shadow bg-light-background dark:bg-dark-card dark:border-dark-accent text-left'
+      >
+        <div className='flex justify-between items-start'>
+          {isEditing ? (
+            <div className='w-full space-y-2'>
+              <select
+                name='status'
+                value={editFormData?.status || ''}
+                onChange={onEditChange}
+                className='p-2 border rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-white'
+              >
+                <option value='Applied'>Applied</option>
+                <option value='Interviewing'>Interview</option>
+                <option value='Offer'>Offer</option>
+                <option value='Rejected'>Rejected</option>
+              </select>
+              {showOfferDate && (
+                <div className='flex items-center gap-2'>
+                  <span className='text-xs text-gray-600 dark:text-gray-300'>
+                    Offer date:
+                  </span>
+                  <input
+                    type='date'
+                    value={offerDate || ''}
+                    onChange={(e) => setOfferDate?.(e.target.value)}
+                    className='text-xs p-1 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white'
+                  />
+                </div>
+              )}
+              {showRejectDate && (
+                <div className='flex items-center gap-2'>
+                  <span className='text-xs text-gray-600 dark:text-gray-300'>
+                    Rejection date:
+                  </span>
+                  <input
+                    type='date'
+                    value={rejectDate || ''}
+                    onChange={(e) => setRejectDate?.(e.target.value)}
+                    className='text-xs p-1 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white'
+                  />
+                </div>
+              )}
+              <div className='flex items-center gap-2 flex-wrap'>
+                <span className='text-xs text-gray-600 dark:text-gray-300'>
+                  Interview Round:
+                </span>
+                <button
+                  type='button'
+                  onClick={() => setRoundDelta?.((roundDelta ?? 0) - 1)}
+                  className='text-xs px-2 py-1 rounded border dark:border-gray-600 dark:text-dark-text hover:bg-gray-100 dark:hover:bg-gray-700'
+                  title='Remove last interview entry'
+                  aria-label='Remove last interview entry'
+                >
+                  −
+                </button>
+                <button
+                  type='button'
+                  onClick={() => setRoundDelta?.(Math.min(1, (roundDelta ?? 0) + 1))}
+                  className='text-xs px-2 py-1 rounded border dark:border-gray-600 dark:text-dark-text hover:bg-gray-100 dark:hover:bg-gray-700'
+                  title='Plan to add one interview entry'
+                  aria-label='Plan to add one interview entry'
+                >
+                  +
+                </button>
+                <span className='text-xs text-gray-600 dark:text-gray-300'>
+                  : {roundDelta && roundDelta > 0 ? `+${Math.min(1, roundDelta)}` : roundDelta ?? 0}
+                </span>
+                <span className='text-xs text-gray-600 dark:text-gray-300 ml-2'>
+                  on
+                </span>
+                <input
+                  type='date'
+                  value={roundAddDate || ''}
+                  onChange={(e) => setRoundAddDate?.(e.target.value)}
+                  className='text-xs p-1 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white'
+                  title='Date for the interview round to add'
+                />
+                {(() => {
+                  const datesDesc = Array.isArray(editFormData?.status_history)
+                    ? editFormData.status_history
+                        .filter((s) => s.status === 'Interviewing' && s.date)
+                        .map((s) => s.date)
+                        .sort((a, b) => (a < b ? 1 : a > b ? -1 : 0))
+                    : [];
+                  if ((roundDelta ?? 0) < 0) {
+                    const n = Math.min(Math.abs(roundDelta ?? 0), datesDesc.length);
+                    if (n > 0) {
+                      const first = datesDesc[0];
+                      return (
+                        <span className='text-[11px] text-gray-600 dark:text-gray-400 ml-2'>
+                          Removing: {first}
+                          {n > 1 ? ` (+${n - 1} more)` : ''}
+                        </span>
+                      );
+                    }
+                    return (
+                      <span className='text-[11px] text-gray-600 dark:text-gray-400 ml-2'>
+                        Nothing to remove
+                      </span>
+                    );
+                  }
+                  if ((roundDelta ?? 0) > 0) {
+                    return (
+                      <span className='text-[11px] text-gray-600 dark:text-gray-400 ml-2'>
+                        Adding on: {roundAddDate}
+                      </span>
+                    );
+                  }
+                  return null;
+                })()}
+              </div>
+              <textarea
+                name='notes'
+                value={editFormData?.notes || ''}
+                onChange={onEditChange}
+                className='w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white'
+                rows={3}
+              />
+              <div className='flex flex-wrap gap-4'>
+                {tagOptions.map((tag) => (
+                  <label
+                    key={tag}
+                    className='flex items-center space-x-2 dark:text-dark-text'
+                  >
+                    <input
+                      type='checkbox'
+                      checked={safeTags.includes(tag)}
+                      onChange={() => onTagToggle?.(tag)}
+                      className='dark:bg-gray-700'
+                    />
+                    <span>{tag}</span>
+                  </label>
+                ))}
+              </div>
+              <div className='space-x-2'>
+                <button
+                  onClick={onSave}
+                  className='bg-green-500 text-white px-2 py-1 rounded dark:bg-cyan-500 dark:hover:bg-cyan-400'
+                >
+                  Save
+                </button>
+                <button
+                  onClick={onCancel}
+                  className='bg-gray-400 text-white px-2 py-1 rounded dark:bg-cyan-800 dark:hover:bg-cyan-900'
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className='flex-1'>
+                <div className='font-semibold dark:text-dark-text'>
+                  {job.title} @ {job.company}
+                </div>
+                {job.link && (
+                  <div className='mt-1'>
+                    <a
+                      href={job.link}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      title={job.link}
+                      className='inline-flex items-center gap-1 text-sm font-medium text-light-accent hover:underline dark:text-dark-accent dark:hover:text-dark-accentHover'
+                    >
+                      View
+                    </a>
+                  </div>
+                )}
+                <div className='dark:text-dark-text'>
+                  Status: {job.status}
+                </div>
+                {job.status_history?.length > 0 && (
+                  <div className='text-xs text-gray-500 mt-1 dark:text-dark-text'>
+                    {job.status_history.map((s, index) => (
+                      <div key={index}>
+                        {s.status === 'Interviewing'
+                          ? 'Interviewed'
+                          : s.status === 'Offer'
+                          ? 'Offered'
+                          : s.status}{' '}
+                        on {s.date}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {(() => {
+                  const rounds = countInterviewRoundsForJob(job);
+                  if (rounds < 1) return null;
+                  const label = `Interview Round${rounds === 1 ? '' : 's'}: `;
+                  return (
+                    <div className='text-xs text-gray-500 mt-1 dark:text-dark-text'>
+                      {label}
+                      {rounds}
+                    </div>
+                  );
+                })()}
+                <div className='text-gray-700 dark:text-dark-text'>
+                  Notes: {job.notes || ''}
+                </div>
+                {job.tags && (
+                  <div className='mt-2 flex flex-wrap gap-2'>
+                    {job.tags.split(',').map((tag, index) => {
+                      const trimmed = tag.trim();
+                      let bgClass = 'bg-gray-100';
+                      let textClass = 'text-gray-800';
+                      if (trimmed === 'Remote' || trimmed === 'Hybrid' || trimmed === 'On-Site') {
+                        bgClass =
+                          'bg-light-tag-remoteBg text-light-tag-remoteText dark:bg-dark-tag-bg dark:text-dark-tag-text';
+                        textClass = '';
+                      } else if (trimmed === 'Referral') {
+                        bgClass =
+                          'bg-light-tag-referralBg text-light-tag-referralText dark:bg-dark-tag-bg dark:text-dark-tag-text';
+                        textClass = '';
+                      } else if (trimmed === 'Urgent') {
+                        bgClass =
+                          'bg-light-tag-urgentBg text-light-tag-urgentText dark:bg-dark-tag-bg dark:text-dark-tag-text';
+                        textClass = '';
+                      } else if (trimmed === 'Startup') {
+                        bgClass =
+                          'bg-light-tag-startupBg text-light-tag-startupText dark:bg-dark-tag-bg dark:text-dark-tag-text';
+                        textClass = '';
+                      }
+                      return (
+                        <span
+                          key={index}
+                          className={`${bgClass} ${textClass} text-xs font-semibold px-2 py-1 rounded`}
+                        >
+                          {trimmed}
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+              <div className='flex flex-col sm:flex-row sm:items-center sm:gap-2 text-right gap-1'>
+                <button
+                  onClick={() => onEditClick?.(job)}
+                  className='text-white px-2 py-1 rounded bg-light-accent hover:bg-light-accentHover dark:bg-cyan-500 dark:hover:bg-cyan-400 dark:hover:shadow-[0_0_10px_#22d3ee] text-sm sm:text-base'
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => onDelete?.(job.id)}
+                  className='px-2 py-1 rounded text-white bg-red-400 hover:bg-red-500 dark:bg-red-600 dark:hover:bg-red-500 dark:hover:shadow-[0_0_10px_#f87171] text-sm sm:text-base'
+                >
+                  Delete
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </OuterTag>
+  );
+});
+
+export default JobRow;

--- a/frontend/src/context/ModeContext.jsx
+++ b/frontend/src/context/ModeContext.jsx
@@ -114,4 +114,5 @@ export const ModeProvider = ({ children }) => {
   );
 };
 
+/* eslint-disable-next-line react-refresh/only-export-components */
 export const useMode = () => useContext(ModeContext);

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,11 +1,59 @@
 import '@testing-library/jest-dom/vitest';
+import React from 'react';
 import { afterEach, beforeAll, beforeEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import { indexedDB, IDBKeyRange } from 'fake-indexeddb';
 
+vi.mock('react-chartjs-2', () => ({
+  Bar: React.forwardRef<HTMLDivElement>((_props, ref) =>
+    React.createElement('div', {
+      ref,
+      'data-testid': 'chart-mock',
+      role: 'img',
+      'aria-label': 'Chart placeholder'
+    })
+  )
+}));
+
 if (!(globalThis as any).indexedDB) {
   (globalThis as any).indexedDB = indexedDB;
   (globalThis as any).IDBKeyRange = IDBKeyRange;
+}
+
+if (!(globalThis as any).ResizeObserver) {
+  class ResizeObserverMock {
+    private callback: (entries: any[], observer: ResizeObserverMock) => void;
+
+    constructor(callback: (entries: any[], observer: ResizeObserverMock) => void) {
+      this.callback = callback;
+    }
+
+    observe(target: Element) {
+      const rect = target.getBoundingClientRect
+        ? target.getBoundingClientRect()
+        : { width: 0, height: 0, top: 0, bottom: 0, left: 0, right: 0, x: 0, y: 0 };
+
+      this.callback(
+        [
+          {
+            contentRect: rect,
+            target
+          }
+        ],
+        this
+      );
+    }
+
+    unobserve() {
+      // no-op
+    }
+
+    disconnect() {
+      // no-op
+    }
+  }
+
+  (globalThis as any).ResizeObserver = ResizeObserverMock;
 }
 
 beforeAll(() => {


### PR DESCRIPTION
## Summary
- Convert the job list to a single browser-scroll experience with `react-virtuoso`, keeping the `<30 items` fallback for small result sets.
- Add a sticky search/filter bar (with `/` focus shortcut), compact mobile layout, persistent “Hide insights,” jump-to-top FAB, and a cleaner “View” link label.
- Center and resize analytics visuals, stack edit/delete on phones, and unify spacing across modes; mock Chart.js in tests to avoid canvas warnings.

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test`
- `npm --prefix frontend run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sticky search/filter bar with "/" shortcut, CSV export for filtered results, "Jump to top" button, and inline analytics/insights chart

* **Improvements**
  * Window-scrolled virtualization for long lists (with static-list fallback for <30 items), smoother layout refresh after edits, improved dark-mode and responsive chart and list behavior, safer link and tag rendering, enhanced editing/history flows

* **Documentation**
  * Added Performance section to README

* **Bug Fixes**
  * Improved error logging for import failures

* **Tests**
  * Added test mocks for charts and ResizeObserver
<!-- end of auto-generated comment: release notes by coderabbit.ai -->